### PR TITLE
Fix browser-owned app shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ samosa app
 
 Access the interface at <http://127.0.0.1:8642>. Available settings include:
 
+`samosa app` is browser-owned: closing the final Samosa tab stops the gateway,
+the loaded model, and Samosa helper processes after a short refresh-safe grace
+period. Use `samosa serve` only when you intentionally want the service to
+remain running without an open browser tab. The Privacy settings page also has
+a **Stop local processes** action for immediate authenticated shutdown.
+
 - Model selection and downloading.
 - Grouped Text LLM, Vision, OCR, and Voice model settings with live readiness.
 - Automatic chat-attachment routing, hardware-adaptive image resizing, and

--- a/dist/samosa
+++ b/dist/samosa
@@ -292,6 +292,12 @@ process_command() {
   ps -p "$pid" -o command= 2>/dev/null || true
 }
 
+process_running() {
+  pid=$1
+  state=$(ps -p "$pid" -o stat= 2>/dev/null | tr -d '[:space:]' || true)
+  case "$state" in ''|Z*) return 1 ;; *) return 0 ;; esac
+}
+
 is_samosa_server_pid() {
   pid=$1
   command=$(process_command "$pid")
@@ -315,6 +321,33 @@ is_samosa_backend_pid() {
   esac
 }
 
+samosa_server_running_pid() {
+  process_running "$1" && is_samosa_server_pid "$1"
+}
+
+samosa_backend_running_pid() {
+  process_running "$1" && is_samosa_backend_pid "$1"
+}
+
+signal_backend_tree() {
+  pid=$1
+  requested_signal=$2
+  pgid=$(ps -p "$pid" -o pgid= 2>/dev/null | tr -d '[:space:]' || true)
+  case "$pgid" in ''|*[!0-9]*|0|1) pgid= ;; esac
+  case "$requested_signal" in
+    TERM)
+      if [ "$pgid" = "$pid" ]; then kill -TERM -- "-$pgid" 2>/dev/null || true
+      else kill -TERM "$pid" 2>/dev/null || true
+      fi
+      ;;
+    KILL)
+      if [ "$pgid" = "$pid" ]; then kill -KILL -- "-$pgid" 2>/dev/null || true
+      else kill -KILL "$pid" 2>/dev/null || true
+      fi
+      ;;
+  esac
+}
+
 cleanup_stale_backend() {
   pid=""
   if [ -s "$BACKEND_PID_FILE" ]; then
@@ -328,7 +361,7 @@ cleanup_stale_backend() {
     rm -f "$BACKEND_PID_FILE"
     return 0
   fi
-  if ! kill -0 "$pid" 2>/dev/null; then
+  if ! process_running "$pid"; then
     rm -f "$BACKEND_PID_FILE"
     return 0
   fi
@@ -337,17 +370,16 @@ cleanup_stale_backend() {
     fail "private model port $BACKEND_PORT is occupied by process $pid: $command"
   fi
   say "recovering stale local model process $pid"
-  kill -TERM "$pid" 2>/dev/null || true
+  signal_backend_tree "$pid" TERM
   i=0
-  while [ -n "$(port_owner_pid "$BACKEND_PORT")" ] && [ "$i" -lt 50 ]; do
+  while samosa_backend_running_pid "$pid" && [ "$i" -lt 80 ]; do
     sleep 0.1
     i=$((i + 1))
   done
-  owner=$(port_owner_pid "$BACKEND_PORT")
-  if [ "$owner" = "$pid" ]; then
-    kill -KILL "$pid" 2>/dev/null || true
+  if samosa_backend_running_pid "$pid"; then
+    signal_backend_tree "$pid" KILL
     i=0
-    while [ -n "$(port_owner_pid "$BACKEND_PORT")" ] && [ "$i" -lt 20 ]; do
+    while samosa_backend_running_pid "$pid" && [ "$i" -lt 20 ]; do
       sleep 0.1
       i=$((i + 1))
     done
@@ -566,6 +598,26 @@ start_server() {
 }
 
 stop_server() {
+  # Capture the actual listeners before shutdown starts. launchd can replace
+  # the short-lived bootstrap PID in server.pid, and both gateway and backend
+  # close their sockets before their final cleanup has completed. Waiting only
+  # on the marker or listener therefore used to report success too early.
+  tracked_server_pid=$(port_owner_pid)
+  if [ -z "$tracked_server_pid" ] && [ -s "$PID_FILE" ]; then
+    tracked_server_pid=$(tr -d '[:space:]' <"$PID_FILE")
+  fi
+  case "$tracked_server_pid" in ''|*[!0-9]*) tracked_server_pid= ;; esac
+  if [ -n "$tracked_server_pid" ] && ! is_samosa_server_pid "$tracked_server_pid"; then
+    tracked_server_pid=
+  fi
+  tracked_backend_pid=
+  if [ -s "$BACKEND_PID_FILE" ]; then
+    tracked_backend_pid=$(tr -d '[:space:]' <"$BACKEND_PID_FILE")
+    case "$tracked_backend_pid" in ''|*[!0-9]*) tracked_backend_pid= ;; esac
+    if [ -n "$tracked_backend_pid" ] && ! is_samosa_backend_pid "$tracked_backend_pid"; then
+      tracked_backend_pid=
+    fi
+  fi
   if server_running && [ -s "$UI_TOKEN_FILE" ]; then
     ui_token=$(tr -d '\r\n' <"$UI_TOKEN_FILE")
     if [ -n "$ui_token" ]; then
@@ -585,18 +637,30 @@ stop_server() {
       i=$((i + 1))
     done
   fi
-  if [ -f "$PID_FILE" ]; then
-    pid=$(cat "$PID_FILE" 2>/dev/null || true)
+  if [ -n "$tracked_server_pid" ]; then
     i=0
-    while [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+    while samosa_server_running_pid "$tracked_server_pid" && [ "$i" -lt 120 ]; do
       sleep 0.1
       i=$((i + 1))
     done
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      kill -TERM "$pid" 2>/dev/null || true
+    if samosa_server_running_pid "$tracked_server_pid"; then
+      kill -TERM "$tracked_server_pid" 2>/dev/null || true
+      i=0
+      while samosa_server_running_pid "$tracked_server_pid" && [ "$i" -lt 50 ]; do
+        sleep 0.1
+        i=$((i + 1))
+      done
     fi
-    rm -f "$PID_FILE"
+    if samosa_server_running_pid "$tracked_server_pid"; then
+      kill -KILL "$tracked_server_pid" 2>/dev/null || true
+      i=0
+      while samosa_server_running_pid "$tracked_server_pid" && [ "$i" -lt 20 ]; do
+        sleep 0.1
+        i=$((i + 1))
+      done
+    fi
   fi
+  rm -f "$PID_FILE"
   pid=$(port_owner_pid)
   if [ -n "$pid" ] && is_samosa_server_pid "$pid"; then
     kill -TERM "$pid" 2>/dev/null || true
@@ -610,6 +674,23 @@ stop_server() {
     fi
   fi
   cleanup_stale_backend
+  if [ -n "$tracked_backend_pid" ] && samosa_backend_running_pid "$tracked_backend_pid"; then
+    signal_backend_tree "$tracked_backend_pid" TERM
+    i=0
+    while samosa_backend_running_pid "$tracked_backend_pid" && [ "$i" -lt 80 ]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+    if samosa_backend_running_pid "$tracked_backend_pid"; then
+      signal_backend_tree "$tracked_backend_pid" KILL
+    fi
+  fi
+  if [ -n "$tracked_server_pid" ] && samosa_server_running_pid "$tracked_server_pid"; then
+    fail "Samosa gateway process $tracked_server_pid did not stop"
+  fi
+  if [ -n "$tracked_backend_pid" ] && samosa_backend_running_pid "$tracked_backend_pid"; then
+    fail "Samosa model process $tracked_backend_pid did not stop"
+  fi
   echo "Samosa server stopped."
 }
 
@@ -737,12 +818,12 @@ fi
 
 if [ "${1:-}" = "app" ]; then
   shift
-  # A normal app launch uses the same persistent supervisor as `serve`, so
-  # the local UI cannot disappear when a terminal or automation host reaps
-  # detached children after this short-lived launcher returns. Browser-owned
-  # shutdown remains available for lifecycle-specific integration tests and
-  # compatibility via an explicit environment override.
-  APP_LIFECYCLE="${SAMOSA_APP_LIFECYCLE:-0}"
+  # `app` belongs to the browser session: closing its final Samosa tab must
+  # terminate the gateway and every model/helper process it owns. KeepAlive is
+  # deliberately reserved for `samosa serve`, whose documented purpose is an
+  # independently running service. The override remains available for tests
+  # and unusual embedding environments, but browser ownership is the default.
+  APP_LIFECYCLE="${SAMOSA_APP_LIFECYCLE:-1}"
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --lan) BIND_ADDRESS=0.0.0.0; LAN_MODE=1 ;;

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -203,6 +203,12 @@ samosa serve --stop
 ```
 
 The gateway listens only on `127.0.0.1:8642` by default.
+`samosa serve` is an independently running service and remains alive when all
+browser tabs close. In contrast, `samosa app` owns the gateway/model tree from
+the browser: closing the final Samosa tab stops the entire tree after a short
+grace period that allows ordinary refreshes to reconnect. **Stop local
+processes** in Privacy settings and `samosa serve --stop` both perform an
+immediate authenticated shutdown.
 
 ## LAN access
 

--- a/docs/regressions/app-server-unexpected-shutdown-2026-08-16.md
+++ b/docs/regressions/app-server-unexpected-shutdown-2026-08-16.md
@@ -18,8 +18,13 @@ was not removed; its gateway/backend process had been stopped.
 
 ## Fix
 
-- Browser lifecycle events never stop the gateway. Refresh reconnects to the
-  same process and selected model.
+- `samosa app` is browser-owned. A close event removes that tab from the active
+  client set; closing the final tab stops the gateway and its complete model
+  process group after a 2.5-second grace period. A refresh reconnects before
+  that deadline and preserves the same process and selected model. Multiple
+  tabs are safe because only the final close initiates shutdown.
+- `samosa serve` remains explicitly persistent and ignores browser lifecycle
+  closure, so headless and intentional background use still works.
 - Both shutdown routes require the current random UI token.
 - The explicit `samosa serve --stop` path reads that token and requests a
   clean shutdown before unregistering the launchd job; it uses a direct

--- a/tests/test_samosa_app_lifecycle.sh
+++ b/tests/test_samosa_app_lifecycle.sh
@@ -62,18 +62,31 @@ EOF
     sh "$ROOT/dist/samosa" serve --stop >/dev/null
 fi
 
-# The user-facing default must use the persistent service path. The launcher
-# returns immediately, but the app must remain reachable from a later process
-# instead of depending on a detached child surviving its parent shell.
+# The user-facing app default must be browser-owned and must not register a
+# launchd KeepAlive job. Activity Monitor-style termination of its gateway
+# must also stop the model and stay stopped.
 SAMOSA_HOME="$HOME_DIR" SAMOSA_RELEASE_DIR="$RELEASE_DIR" SAMOSA_PORT="$PORT" \
   SAMOSA_OPEN="$TMP/open" sh "$ROOT/dist/samosa" app >/dev/null
 DEFAULT_HEALTH=$(curl -fsS "http://127.0.0.1:$PORT/healthz")
-printf '%s' "$DEFAULT_HEALTH" | grep -q '"app_owned":false'
-SAMOSA_HOME="$HOME_DIR" SAMOSA_RELEASE_DIR="$RELEASE_DIR" SAMOSA_PORT="$PORT" \
-  sh "$ROOT/dist/samosa" serve --stop >/dev/null
+printf '%s' "$DEFAULT_HEALTH" | grep -q '"app_owned":true'
+DEFAULT_GW_PID=$(tr -d '\r\n' <"$HOME_DIR/server.pid")
+DEFAULT_BACKEND_PID=$(printf '%s' "$DEFAULT_HEALTH" | sed -n 's/.*"pid":\([0-9][0-9]*\).*/\1/p')
+[ -n "$DEFAULT_GW_PID" ] && [ -n "$DEFAULT_BACKEND_PID" ]
+kill -TERM "$DEFAULT_GW_PID"
+i=0
+while kill -0 "$DEFAULT_GW_PID" 2>/dev/null && [ "$i" -lt 200 ]; do
+  sleep 0.05
+  i=$((i + 1))
+done
+kill -0 "$DEFAULT_GW_PID" 2>/dev/null && { echo "FAIL: default app gateway survived SIGTERM" >&2; exit 1; }
+kill -0 "$DEFAULT_BACKEND_PID" 2>/dev/null && { echo "FAIL: default app backend survived gateway SIGTERM" >&2; exit 1; }
+sleep 0.3
+curl -fsS --max-time 1 "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1 && {
+  echo "FAIL: launchd respawned the default app gateway" >&2; exit 1;
+}
 
-# The explicit browser-owned compatibility mode must still transition cleanly
-# from an ordinary launchd-owned service without racing its stale server.pid.
+# The browser-owned default must transition cleanly from an ordinary
+# launchd-owned `serve` process without racing its stale server.pid.
 if [ "$(uname -s)" = Darwin ] && command -v launchctl >/dev/null 2>&1; then
   SAMOSA_HOME="$HOME_DIR" SAMOSA_RELEASE_DIR="$RELEASE_DIR" SAMOSA_PORT="$PORT" \
     sh "$ROOT/dist/samosa" serve >/dev/null
@@ -82,8 +95,7 @@ if [ "$(uname -s)" = Darwin ] && command -v launchctl >/dev/null 2>&1; then
   printf '%s' "$SERVICE_HEALTH" | grep -q '"app_owned":false'
 
   SAMOSA_HOME="$HOME_DIR" SAMOSA_RELEASE_DIR="$RELEASE_DIR" SAMOSA_PORT="$PORT" \
-    SAMOSA_OPEN="$TMP/open" SAMOSA_APP_LIFECYCLE=1 \
-    sh "$ROOT/dist/samosa" app >/dev/null
+    SAMOSA_OPEN="$TMP/open" sh "$ROOT/dist/samosa" app >/dev/null
   i=0
   while [ "$i" -lt 100 ]; do
     TRANSITION_HEALTH=$(curl -fsS "http://127.0.0.1:$PORT/healthz" 2>/dev/null || true)
@@ -116,7 +128,7 @@ done
 [ "$i" -lt 100 ] || { echo "FAIL: stale backend fixture did not start" >&2; exit 1; }
 
 if ! SAMOSA_HOME="$HOME_DIR" SAMOSA_RELEASE_DIR="$RELEASE_DIR" SAMOSA_PORT="$PORT" \
-  SAMOSA_OPEN="$TMP/open" SAMOSA_VOICE_TRACE_AUTO=1 SAMOSA_APP_LIFECYCLE=1 \
+  SAMOSA_OPEN="$TMP/open" SAMOSA_VOICE_TRACE_AUTO=0 \
   sh "$ROOT/dist/samosa" app >/dev/null; then
   echo "FAIL: app-owned gateway startup log:" >&2
   sed -n '1,240p' "$HOME_DIR/server.log" >&2 || true
@@ -151,6 +163,33 @@ BACKEND_PID=$(printf '%s' "$HEALTH" | sed -n 's/.*"pid":\([0-9][0-9]*\).*/\1/p')
 [ -n "$BACKEND_PID" ] && kill -0 "$BACKEND_PID" 2>/dev/null
 TOKEN=$(tr -d '\r\n' <"$HOME_DIR/run/ui-token")
 [ -n "$TOKEN" ]
+
+# The browser troubleshooting button uses this authenticated kill route. It
+# must terminate the same app-owned gateway/backend tree without a respawn.
+curl -fsS -H "X-Samosa-Token: $TOKEN" -X POST \
+  "http://127.0.0.1:$PORT/v1/kill" >/dev/null
+i=0
+while kill -0 "$GW_PID" 2>/dev/null && [ "$i" -lt 200 ]; do
+  sleep 0.05
+  i=$((i + 1))
+done
+kill -0 "$GW_PID" 2>/dev/null && { echo "FAIL: browser kill left gateway running" >&2; exit 1; }
+kill -0 "$BACKEND_PID" 2>/dev/null && { echo "FAIL: browser kill left backend running" >&2; exit 1; }
+sleep 0.3
+curl -fsS --max-time 1 "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1 && {
+  echo "FAIL: browser-killed gateway was respawned" >&2; exit 1;
+}
+
+# Start a fresh default app instance for refresh-versus-final-tab-close checks.
+SAMOSA_HOME="$HOME_DIR" SAMOSA_RELEASE_DIR="$RELEASE_DIR" SAMOSA_PORT="$PORT" \
+  SAMOSA_OPEN="$TMP/open" SAMOSA_VOICE_TRACE_AUTO=1 \
+  sh "$ROOT/dist/samosa" app >/dev/null
+GW_PID=$(tr -d '\r\n' <"$HOME_DIR/server.pid")
+HEALTH=$(curl -fsS "http://127.0.0.1:$PORT/healthz")
+printf '%s' "$HEALTH" | grep -q '"app_owned":true'
+BACKEND_PID=$(printf '%s' "$HEALTH" | sed -n 's/.*"pid":\([0-9][0-9]*\).*/\1/p')
+TOKEN=$(tr -d '\r\n' <"$HOME_DIR/run/ui-token")
+[ -n "$GW_PID" ] && [ -n "$BACKEND_PID" ] && [ -n "$TOKEN" ]
 
 # Refresh closes the old document and opens a replacement. The grace period
 # must preserve both the gateway and its already-loaded backend.

--- a/tests/test_samosa_llama_lifecycle.sh
+++ b/tests/test_samosa_llama_lifecycle.sh
@@ -40,7 +40,7 @@ printf '#!/bin/sh\nexit 0\n' >"$TMP/open"
 chmod +x "$TMP/open"
 
 SAMOSA_HOME="$HOME_DIR" SAMOSA_RELEASE_DIR="$RELEASE_DIR" SAMOSA_PORT="$PORT" \
-  SAMOSA_OPEN="$TMP/open" SAMOSA_VOICE_TRACE_AUTO=1 SAMOSA_APP_LIFECYCLE=1 \
+  SAMOSA_OPEN="$TMP/open" SAMOSA_VOICE_TRACE_AUTO=1 \
   sh "$ROOT/dist/samosa" app >/dev/null
 
 GW_PID=$(tr -d '\n' <"$HOME_DIR/server.pid")


### PR DESCRIPTION
## Summary

- restore browser ownership as the default for `samosa app` while keeping `samosa serve` persistent
- stop the real gateway and full model process group, including stale/native backends, before reporting success
- cover refresh-safe final-tab shutdown, authenticated kill, direct gateway termination, stale recovery, Qwen, llama, and no-respawn behavior
- document the app-versus-serve lifecycle contract

## Root cause

A prior regression changed normal `samosa app` launches to the persistent KeepAlive service path. Browser lifecycle shutdown was still present, but disabled by default, so launchd could respawn the gateway and its selected model. The stop wrapper also trusted stale PID/port markers and could return before the actual processes exited.

## Validation

- `make test`
- `make app-lifecycle-test` (three consecutive focused runs)
- `make detached-service-test`
- `make test-lan-access`
- `sh tests/test_samosa_wrapper.sh`
- installed native Qwen3.6 lifecycle: refresh preserved gateway/model; final close removed both exact PIDs and ports 8642/8643 with no respawn
- installed `samosa serve --stop`: removed both exact gateway/Qwen PIDs before returning with no respawn
- `git diff --check`