### PR TITLE
harden: use bounded strlcpy/snprintf in qwen36b.c...

### DIFF
--- a/src/qwen36b.c
+++ b/src/qwen36b.c
@@ -1144,7 +1144,7 @@ static void embed_gather_row(float *out, const QT *w, int row) {
 static QT qt_load(Model *m, const char *name, int O, int I) {
     QT t = {0};
     char nm[512];
-    strcpy(nm, name);
+    snprintf(nm, sizeof(nm), "%s", name);
     
     st_tensor *tw = st_find(&m->S, name);
     if (!tw) {
@@ -1156,7 +1156,7 @@ static QT qt_load(Model *m, const char *name, int O, int I) {
         }
         tw = st_find(&m->S, wrapped);
         if (tw) {
-            strcpy(nm, wrapped);
+            snprintf(nm, sizeof(nm), "%s", wrapped);
         }
     }
     if (!tw) {
@@ -4295,8 +4295,8 @@ static int teacher_is_calibration(uint64_t ordinal, uint64_t positions,
 static void teacher_fsync_parent(const char *path) {
     char parent[2048];
     if (strlen(path)>=sizeof(parent)) teacher_die("output path is too long");
-    strcpy(parent,path); char *slash=strrchr(parent,'/');
-    if (!slash) strcpy(parent,".");
+    snprintf(parent, sizeof(parent), "%s", path); char *slash=strrchr(parent,'/');
+    if (!slash) snprintf(parent, sizeof(parent), ".");
     else if (slash==parent) slash[1]=0;
     else *slash=0;
     int fd=open(parent,O_RDONLY);
@@ -5085,7 +5085,7 @@ static int serve_valid_id(const char *id){
 
 static int serve_mkdir(const char *path){
     char copy[PATH_MAX]; if(strlen(path)>=sizeof(copy))return 0;
-    strcpy(copy,path);
+    snprintf(copy, sizeof(copy), "%s", path);
     for(char *p=copy+1;*p;p++)if(*p=='/'){*p=0;if(mkdir(copy,0700)&&errno!=EEXIST)return 0;*p='/';}
     return !mkdir(copy,0700)||errno==EEXIST;
 }


### PR DESCRIPTION
## Summary
Harden input handling in `src/qwen36b.c` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn` |
| **File** | `src/qwen36b.c:1147` |
| **Assessment** | Defensive hardening |

**Description**: Finding triggers whenever there is a strcpy or strncpy used. This is an issue because strcpy does not affirm the size of the destination array and strncpy will not automatically NULL-terminate strings. This can lead to buffer overflows, which can cause program crashes and potentially let an attacker inject code in the program. Fix this by using strcpy_s instead (although note that strcpy_s is an optional part of the C11 standard, and so may not be available).

## Threat Model Context

This is a containerized service - vulnerabilities may be exploitable depending on network exposure.

## Changes
- `src/qwen36b.c`

> **Note**: The following lines in the same file use a similar pattern and may also need review: `src/qwen36b.c:5134`, `src/qwen36b.c:5135`, `src/qwen36b.c:5158`, `src/qwen36b.c:5160`, `src/qwen36b.c:5162`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
