### PR TITLE
Reuse resident document context across text models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ test-ui-setup: test-fake-download-server test_fake_openai_backend samosa-gateway
 	node tests/test_web_activity_ui.mjs
 	node tests/test_developer_mode_ui.mjs
 
-compiled-gateway-test: samosa-gateway samosa-jobsd samosa-fs test_fake_openai_backend test_fake_native_summarizer test-native-summarizer-supervisor test-runtime-settings tests/test_compiled_gateway.sh tests/test_settings_compact_proxy.sh tests/test_attachments.sh tests/test_web_search.sh tests/test_developer_trace.sh
+compiled-gateway-test: samosa-gateway samosa-jobsd samosa-fs test_fake_openai_backend test_fake_native_summarizer test-native-summarizer-supervisor test-runtime-settings tests/test_compiled_gateway.sh tests/test_settings_compact_proxy.sh tests/test_attachments.sh tests/test_document_context_prefix.sh tests/test_web_search.sh tests/test_developer_trace.sh
 	BUILD_DIR="$(BUILD_DIR)" \
 	SAMOSA_COMPILED_GATEWAY="$$PWD/$(BUILD_DIR)/samosa-gateway" \
 	SAMOSA_COMPILED_JOBSD="$$PWD/$(BUILD_DIR)/samosa-jobsd" \
@@ -336,6 +336,9 @@ compiled-gateway-test: samosa-gateway samosa-jobsd samosa-fs test_fake_openai_ba
 	SAMOSA_EXTRACT="$${SAMOSA_EXTRACT:-$$PWD/$(BUILD_DIR)/samosa-extract}" \
 	SAMOSA_OCR="$${SAMOSA_OCR:-$$PWD/$(BUILD_DIR)/samosa-ocr}" \
 	sh tests/test_attachments.sh
+	SAMOSA_EXTRACT="$${SAMOSA_EXTRACT:-$$PWD/$(BUILD_DIR)/samosa-extract}" \
+	SAMOSA_OCR="$${SAMOSA_OCR:-$$PWD/$(BUILD_DIR)/samosa-ocr}" \
+	sh tests/test_document_context_prefix.sh
 	SAMOSA_COMPILED_GATEWAY="$$PWD/$(BUILD_DIR)/samosa-gateway" \
 	SAMOSA_FAKE_BACKEND="$$PWD/$(BUILD_DIR)/test_fake_openai_backend" \
 	SAMOSA_FAKE_SUMMARIZER="$$PWD/$(BUILD_DIR)/test_fake_native_summarizer" \

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Test logs and regression benchmarks are located in [docs/regressions](docs/regre
 | Password-protected LAN access | [docs/LAN_ACCESS.md](docs/LAN_ACCESS.md) |
 | Model Specifications & Network | [docs/MODELS_AND_INTERNET.md](docs/MODELS_AND_INTERNET.md) |
 | Gateway API | [docs/SERVE_API.md](docs/SERVE_API.md) |
+| Conversation context & document reuse | [docs/CONVERSATION_CONTEXT.md](docs/CONVERSATION_CONTEXT.md) |
 | Chutni folder memory | [docs/CHUTNI_PROTOCOL.md](docs/CHUTNI_PROTOCOL.md) |
 | Architecture | [docs/DESIGN.md](docs/DESIGN.md) |
 | Performance Benchmarks | [docs/PERFORMANCE.md](docs/PERFORMANCE.md) |

--- a/docs/APP_TASKS.md
+++ b/docs/APP_TASKS.md
@@ -98,31 +98,31 @@ are unaffected (serve code compiled but idle in oracle mode); guardrails
 hold in a 15-minute serve soak driven by scripted requests (zero swap,
 writes < 100 MB/h, thermal ≤ moderate at the 2T default).
 
-### A0.2 Conversation slots on the session machinery  ~2 days
+### A0.2 Resident conversation state on the session machinery  ~2 days
 
-**Status (2026-07-14): partially implemented.** `conversation_id` uses sealed,
-atomic `QWSESS01` snapshots, and two real HTTP turns verified exact restore
-without history re-prefill. The four-slot in-RAM LRU, pressure eviction, write
-batching, and four-conversation soak are still open; the current developer
-preview restores the snapshot from disk on every later turn.
+**Status (2026-08-31): implemented with a one-hot policy.** Native Qwen keeps
+the current conversation's transcript and K/V state resident after atomically
+writing its sealed `QWSESS01` checkpoint. A matching next turn continues from
+memory; a conversation switch restores the durable checkpoint. The engine
+evicts on switch, stateless work, compaction, settings changes, shutdown, a
+five-minute idle timeout, or low available memory, and reports the capacity,
+hot tokens, policy, hits, restores, and evictions in `/healthz`.
 
-Per-conversation state without re-prefill: keep N in-RAM conversation slots
-(N=4 default; each ≈ KV bytes of its context + 63 MB state). API:
-`conversation_id` on the completions call; slot hit → continue exactly
-(the byte-identical continuation property is already proven); slot miss →
-restore from the conversation's `QWSESS01` snapshot on disk; snapshot
-written on turn end (atomic tmp+fsync+rename, batched — write-hygiene
-guardrail applies).
+The earlier N=4 proposal was deliberately replaced by one hot conversation per
+active engine. Four simultaneous large K/V allocations are the wrong default
+for a fanless MacBook Air; durability on disk makes one slot sufficient without
+losing conversations. Maple now follows the same one-hot principle with native
+MLX K/V state. Bonsai and Ornith use one llama.cpp slot plus an exact stable
+prompt prefix and `cache_prompt` for cache reuse. See
+[CONVERSATION_CONTEXT.md](CONVERSATION_CONTEXT.md).
 
-Eviction: LRU over slots; RAM budget for slots is explicit and reported in
-`/healthz`; the engine's memory-pressure reflex must also drop cold slots
-(WARN) before the OS swaps.
-
-**Acceptance:** turn 2 of a resumed conversation starts decoding in < 2 s
-(no prompt re-prefill — measure TTFT); slot eviction + snapshot restore
-produces byte-identical continuations (extend the T4.4 A/B/C test across
-the HTTP path); 4 interleaved conversations soak 15 minutes within RAM
-budget and zero swap.
+The remaining optimization debt is Qwen checkpoint write amplification: a
+successful turn still writes one complete synchronous snapshot. Incremental or
+asynchronous checkpointing is open, subject to preserving atomic recovery and
+the prior-good snapshot on failure. Real-model TTFT, eviction/restore, long
+interleaving, thermal, swap, and write-rate soaks remain release measurements;
+synthetic tests cover K/V growth layout, ownership, eviction, health telemetry,
+and cross-backend document-prefix behavior.
 
 ### A0.3 `samosa app` launcher  ~0.5 day
 

--- a/docs/CONVERSATION_CONTEXT.md
+++ b/docs/CONVERSATION_CONTEXT.md
@@ -1,0 +1,205 @@
+# Conversation context and document reuse
+
+Samosa keeps inference on the Mac while browsers on the Mac, a phone, or
+another LAN device remain thin clients. A browser sends messages and displays
+the stream; it does not load a model, hold model K/V memory, or process an
+attached document.
+
+The context design has two complementary layers:
+
+1. Keep the current conversation's model state hot in memory so its next turn
+   can continue without repeating a full prompt prefill.
+2. Keep enough private local state on disk to recover after an eviction,
+   conversation switch, model restart, app restart, or compaction.
+
+The in-memory layer is the fast path. The disk layer is a recovery and
+durability path; writing it does not unload the hot state.
+
+## What happens on a document conversation
+
+On the first turn with a PDF or another text document, the gateway resolves the
+content-addressed attachment, extracts embedded text or runs local OCR when
+needed, and admits a bounded evidence block to the selected text model. It
+records the document identity and extraction mode in the conversation manifest.
+
+For a document small enough for full-context mode, Samosa also saves the exact
+evidence admitted on that turn in:
+
+```text
+~/.samosa/chats/<conversation_id>/document-context.txt
+```
+
+The sidecar is mode `0600`, is stored only on the Mac, and is limited to 256
+KiB. It is plaintext private conversation state, so anyone with access to the
+Mac user account and that directory can read it. It is never served as a public
+asset or sent to a remote service.
+
+On an ordinary follow-up:
+
+- extraction and OCR are not run again;
+- Qwen and Maple continue from native model state and receive only a small
+  document-continuity note on the hot path;
+- Bonsai and Ornith reuse the saved evidence as an identical early prompt
+  prefix, allowing llama.cpp's prompt cache to reuse the prefix K/V state;
+- the full sidecar remains available if native state must be rebuilt or the
+  conversation must be compacted.
+
+The sidecar is accepted only while every bound document is in full-context mode
+and its recorded extractor fingerprint matches the installed reader. Detaching
+any document invalidates the sidecar immediately. A missing, stale, or unreadable
+sidecar never causes Samosa to pretend it still has the document; the gateway
+falls back to the normal extraction/retrieval path or returns a clear context
+error.
+
+Oversized documents use retrieval mode instead. Their extracted/OCR text is
+still cached, so a follow-up does not OCR the source again, but Samosa must run a
+new local passage search for the new question. That query-dependent search is
+expected work and should not be confused with rereading the original file.
+
+## Text-backend behavior
+
+| Backend | Hot continuation | Cold recovery | Full-document follow-up |
+|---|---|---|---|
+| Qwen native | Keeps one live transcript plus native K/V state and appends only the new user turn. | Restores the sealed `QWSESS01` checkpoint for that conversation. | Uses the document already represented in K/V. The sidecar is read only for recovery or compaction. |
+| Maple native | Keeps one live transcript plus MLX K/V caches and appends only the new user turn. | Rebuilds K/V once from the complete browser transcript; recovery-only document evidence is appended once when required. | Uses the document already represented in the hot MLX caches. |
+| Bonsai (llama.cpp) | Uses the server's single prompt-cache slot. The gateway sends `cache_prompt: true`. | Re-prefills the complete request prompt after a cache miss or backend restart. | Places the exact saved evidence in the first user message on every request, before later transcript messages, so the long prefix remains byte-stable and cacheable. |
+| Ornith (llama.cpp) | Same single-slot prompt-prefix cache as Bonsai. | Same cold full-prompt prefill as Bonsai. | Same stable first-user evidence prefix as Bonsai. |
+
+This is capability-based rather than model-name special casing: native engines
+retain their own live K/V representation, while OpenAI-compatible llama.cpp
+engines receive a stable cacheable prefix. All current text-model families are
+covered.
+
+Hidden reasoning is part of native continuation state even though it is not
+copied into the visible browser transcript. This is why Maple and Qwen append to
+their live native transcript instead of reconstructing a hot turn from the
+browser's visible messages.
+
+## One hot conversation, not one model copy per user
+
+Samosa deliberately keeps one hot conversation per active text engine. It does
+not create a model instance or K/V cache for every browser or LAN user. Model
+generation is also serialized: one primary-model response runs at a time and
+other admitted requests wait.
+
+The one-hot policy bounds memory on a fanless MacBook Air. If Device A uses
+conversation A and Device B then submits conversation B, B takes the model slot
+and A's hot state is evicted. Returning to A is a cold restore or rebuild, after
+which A becomes hot again. Multiple devices using the same conversation can
+hit the same hot state, but their generations still run sequentially.
+
+Selecting a different model is global. The old backend is stopped before the
+new backend starts, so its in-memory cache disappears. Durable conversation and
+document state remains local for a later switch back.
+
+## Eviction and memory protection
+
+All backends evict live state on backend shutdown. Native state is also dropped
+when a stateless request or a different conversation needs the single slot, and
+on failures where retaining a partially advanced cache would be unsafe.
+
+Qwen additionally evicts its resident session when:
+
+- it has been idle for 300 seconds by default;
+- available memory falls below 768 MB by default;
+- automatic or manual compaction is about to replace the saved context;
+- runtime context settings change.
+
+The Qwen thresholds can be changed before launch:
+
+```sh
+SAMOSA_HOT_SESSION_IDLE_SECONDS=300
+SAMOSA_HOT_SESSION_MIN_AVAILABLE_MB=768
+```
+
+Set either value to `0` to disable that particular Qwen eviction trigger. The
+reaper acts only while generation and its request queue are idle, so it cannot
+free K/V state while a turn is using it.
+
+Maple is bounded to one hot cache and evicts on conversation switch, stateless
+request, disconnect, generation error, or shutdown. Bonsai and Ornith are
+launched with one llama.cpp server slot (`-np 1`), so their cache is likewise
+bounded by the active backend process.
+
+## Durability, checkpoints, and the write tradeoff
+
+Qwen still writes an atomic `QWSESS01` checkpoint after every successfully
+completed turn. The file is sealed against model geometry and content, then
+written through a temporary file, `fsync`, and rename. The important change is
+that the engine no longer frees the live K/V state after writing it. A normal
+next turn is therefore a memory hit, not a checkpoint reload.
+
+The checkpoint provides:
+
+- exact recovery after idle or memory-pressure eviction;
+- exact recovery after model/app restart;
+- safe switching between conversations without keeping several large K/V
+  allocations resident;
+- a stable source for manual and automatic compaction.
+
+The remaining cost is a full synchronous checkpoint write at successful Qwen
+turn boundaries. Incremental or asynchronous checkpointing is a possible
+future optimization, but it must preserve atomic recovery and the rule that a
+failed/cancelled turn cannot corrupt the last good state.
+
+Maple does not currently write a native K/V checkpoint. Its cold path rebuilds
+from the full browser transcript and the recovery-only document sidecar. The
+llama.cpp backends also treat prompt K/V as an in-process cache and cold-prefill
+from the request after a restart.
+
+## Compaction
+
+Automatic compaction is checked before a turn when projected context usage
+crosses the configured threshold. Compaction necessarily replaces model-facing
+context, so Samosa first evicts native hot state, creates a shorter durable
+context, and then rebuilds from it. Streaming clients receive visible
+`file_activity` events while this happens instead of appearing frozen.
+
+For full-context document conversations, compaction reads
+`document-context.txt` directly and preserves that exact evidence outside the
+model-written summary. Retrieval-mode documents continue to use their normal
+query-specific path.
+
+## Health and diagnosis
+
+Qwen's private backend `/healthz` response includes:
+
+```json
+{
+  "resident_session": {
+    "capacity": 1,
+    "hot": true,
+    "tokens": 2048,
+    "idle_evict_seconds": 300,
+    "min_available_mb": 768,
+    "hits": 3,
+    "restores": 1,
+    "evictions": 0
+  }
+}
+```
+
+Maple reports the same one-slot idea with `available`, `hot`, `tokens`, `hits`,
+and `evictions`. `available: false` means health sampled the backend during
+inference and deliberately did not block waiting for the cache lock.
+
+The browser's document activity wording distinguishes the three meaningful
+paths:
+
+- **Using the already extracted text**: full-context fast path;
+- **Searching the previously extracted text**: retrieval over cached text;
+- **Reading with Samosa's local file reader**: first extraction or a required
+  rebuild.
+
+## Implementation and regression coverage
+
+The shared document policy and payload construction live in
+`src/samosa_gateway.c`. Qwen resident sessions and durable checkpoints live in
+`src/qwen36b.c`. Maple's native hot session lives in
+`src/maple/samosa_maple.cpp`.
+
+Synthetic tests cover Qwen K/V growth and eviction, Qwen compaction activity,
+resident health metadata, saved document-context creation/invalidation, absence
+of full evidence on a native Qwen hot follow-up, and a byte-stable cached
+document prefix across two Ornith-style llama.cpp requests. These tests use
+generated fixture text and never inspect a user's chat directory.

--- a/docs/LAN_ACCESS.md
+++ b/docs/LAN_ACCESS.md
@@ -169,6 +169,15 @@ turn is active. Do not rely on closing a waiting tab to cancel work that has
 already reached the backend. Stop and model controls should be treated as
 shared operational controls.
 
+The devices also share one hot conversation slot in the active text engine.
+Two devices using different conversations do not create two copies of the
+model: when the queued second conversation starts, it replaces the first hot
+K/V or prompt-cache state. Returning to the first conversation performs a cold
+checkpoint restore or prompt rebuild. Full-document extraction remains cached,
+so a cold switch does not normally rerun OCR. See
+[CONVERSATION_CONTEXT.md](CONVERSATION_CONTEXT.md) for the backend matrix and
+eviction policy.
+
 ## Selecting different models from different devices
 
 There is one global active-model selection. Two devices cannot independently

--- a/docs/SERVE_API.md
+++ b/docs/SERVE_API.md
@@ -209,7 +209,18 @@ Content-Type: application/json
 
 The route is OpenAI-compatible. The gateway normalizes Qwen and GGUF streaming
 and appends a `samosa` metadata object to the terminal event when available.
-For Bonsai and Ornith, `conversation_id` enables the durable per-model ledger.
+`conversation_id` selects backend-appropriate continuation state: native live
+K/V plus a durable checkpoint for Qwen, native live K/V with browser-transcript
+recovery for Maple, and a stable cached prompt prefix for Bonsai and Ornith.
+Only one conversation is hot per active text engine; switching conversations
+causes a cold restore or rebuild without loading another model instance. See
+[CONVERSATION_CONTEXT.md](CONVERSATION_CONTEXT.md) for the lifecycle, document
+reuse, eviction, privacy, and recovery contracts.
+
+Qwen's private backend `/healthz` includes a `resident_session` object with
+one-slot capacity, hot token count, eviction policy, hit/restore/eviction
+counters, and scheduler state. Maple reports its one-slot resident state and
+uses `available: false` rather than blocking a health probe during inference.
 
 ## Cancel generation
 

--- a/src/maple/samosa_maple.cpp
+++ b/src/maple/samosa_maple.cpp
@@ -14,13 +14,59 @@
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <cctype>
+#include <mutex>
 
 using namespace samosa::maple;
+
+struct MapleHotSession {
+    std::string conversation_id;
+    std::vector<int> transcript;
+    std::vector<KVCache*> caches;
+    bool valid = false;
+    uint64_t hits = 0;
+    uint64_t evictions = 0;
+};
 
 struct ServerContext {
     MapleModel* model;
     MapleTokenizer* tokenizer;
+    std::mutex inference_mutex;
+    MapleHotSession hot;
+    ServerContext(MapleModel* model_in, MapleTokenizer* tokenizer_in)
+        : model(model_in), tokenizer(tokenizer_in) {}
 };
+
+static void maple_hot_evict(MapleHotSession& hot, const char* reason) {
+    if (!hot.valid) return;
+    std::cerr << "[session] evicted hot Maple conversation "
+              << hot.conversation_id << " (" << (reason ? reason : "policy")
+              << ", " << hot.transcript.size() << " tokens)" << std::endl;
+    for (auto* cache : hot.caches) delete cache;
+    hot.caches.clear();
+    hot.transcript.clear();
+    hot.conversation_id.clear();
+    hot.valid = false;
+    hot.evictions++;
+}
+
+static bool maple_conversation_id_valid(const std::string& id) {
+    if (id.empty() || id.size() > 64) return false;
+    for (unsigned char c : id)
+        if (!(std::isalnum(c) || c == '-' || c == '_')) return false;
+    return true;
+}
+
+static std::vector<KVCache*> maple_new_caches(const MapleModel& model) {
+    std::vector<KVCache*> caches;
+    for (const auto& layer_type : model.args().layer_types) {
+        if (layer_type == "sliding_attention")
+            caches.push_back(new RotatingKVCache(model.args().sliding_window));
+        else
+            caches.push_back(new KVCache());
+    }
+    return caches;
+}
 
 static std::string visible_answer(std::string text, bool started_thinking) {
     const auto think_start = text.find("<think>");
@@ -54,6 +100,14 @@ int samosa_maple_handler(SamosaHttpServer *server, int fd, const SamosaHttpReque
     if (strcmp(req->method, "GET") == 0 && strcmp(req->path, "/healthz") == 0) {
         ecache_stats stats{};
         server_ctx->model->cache_stats(&stats);
+        std::unique_lock<std::mutex> hot_lock(server_ctx->inference_mutex,
+                                              std::try_to_lock);
+        bool hot_available = hot_lock.owns_lock();
+        bool hot = hot_available && server_ctx->hot.valid;
+        size_t hot_tokens = hot ? server_ctx->hot.transcript.size() : 0;
+        uint64_t hot_hits = hot_available ? server_ctx->hot.hits : 0;
+        uint64_t hot_evictions = hot_available ? server_ctx->hot.evictions : 0;
+        if (hot_available) hot_lock.unlock();
         char body[2048];
         std::snprintf(
             body, sizeof(body),
@@ -63,7 +117,9 @@ int samosa_maple_handler(SamosaHttpServer *server, int fd, const SamosaHttpReque
             "\"hits\":%llu,\"misses\":%llu,\"bytes_read\":%llu,"
             "\"bytes_avoided\":%llu,\"evictions\":%llu,"
             "\"failed_admissions\":%llu,\"pressure_warn\":%llu,"
-            "\"pressure_critical\":%llu}}",
+            "\"pressure_critical\":%llu},"
+            "\"resident_session\":{\"capacity\":1,\"available\":%s,"
+            "\"hot\":%s,\"tokens\":%zu,\"hits\":%llu,\"evictions\":%llu}}",
             server_ctx->model->streaming_enabled() ? "true" : "false",
             (unsigned long long)stats.budget_bytes,
             (unsigned long long)stats.payload_bytes,
@@ -76,7 +132,10 @@ int samosa_maple_handler(SamosaHttpServer *server, int fd, const SamosaHttpReque
             (unsigned long long)stats.evictions,
             (unsigned long long)stats.failed_admissions,
             (unsigned long long)stats.pressure_warn_events,
-            (unsigned long long)stats.pressure_critical_events);
+            (unsigned long long)stats.pressure_critical_events,
+            hot_available ? "true" : "false", hot ? "true" : "false",
+            hot_tokens, (unsigned long long)hot_hits,
+            (unsigned long long)hot_evictions);
         return samosa_http_response(fd, 200, "application/json",
                                     body, nullptr);
     }
@@ -141,23 +200,80 @@ int samosa_maple_handler(SamosaHttpServer *server, int fd, const SamosaHttpReque
             return samosa_http_json_error(fd, 400, "invalid_request", "max_tokens must be between 0 and 4096.");
         }
 
+        std::string conversation_id;
+        jval* conversation_val = json_get(root, "conversation_id");
+        if (conversation_val && conversation_val->t == J_STR)
+            conversation_id = conversation_val->str;
+        if (!conversation_id.empty() && !maple_conversation_id_valid(conversation_id)) {
+            json_free(root); free(arena);
+            return samosa_http_json_error(fd, 400, "invalid_conversation_id",
+                                           "conversation_id contains unsupported characters.");
+        }
+        std::string pinned_context;
+        jval* pinned_val = json_get(root, "pinned_context");
+        if (pinned_val && pinned_val->t == J_STR) pinned_context = pinned_val->str;
+        if (pinned_context.size() > 262144) {
+            json_free(root); free(arena);
+            return samosa_http_json_error(fd, 413, "pinned_context_too_large",
+                                           "Pinned document context is too large.");
+        }
+
         json_free(root);
         free(arena);
 
-        std::string prompt = server_ctx->tokenizer->apply_chat_template(msgs, true, enable_thinking);
-        auto input_ids = server_ctx->tokenizer->encode(prompt);
-
         int eos_token = server_ctx->tokenizer->get_eos_token();
+        std::lock_guard<std::mutex> inference_lock(server_ctx->inference_mutex);
+        bool hot_hit = !conversation_id.empty() && server_ctx->hot.valid &&
+                       server_ctx->hot.conversation_id == conversation_id;
+        if (server_ctx->hot.valid && !hot_hit)
+            maple_hot_evict(server_ctx->hot, conversation_id.empty()
+                            ? "stateless request" : "conversation switch");
+        if (max_tokens == 0 && hot_hit) {
+            maple_hot_evict(server_ctx->hot, "zero-token request");
+            hot_hit = false;
+        }
+
+        std::vector<int> input_ids;
+        std::vector<KVCache*> caches;
+        if (hot_hit) {
+            std::string latest_user;
+            for (auto it = msgs.rbegin(); it != msgs.rend(); ++it)
+                if (it->role == "user") { latest_user = it->content; break; }
+            const bool ended = !server_ctx->hot.transcript.empty() &&
+                               server_ctx->hot.transcript.back() == eos_token;
+            std::string continuation = ended ? "\n" : "<|im_end|>\n";
+            continuation += "<|im_start|>user\n" + latest_user +
+                            "<|im_end|>\n<|im_start|>assistant\n";
+            if (enable_thinking) continuation += "<think>\n";
+            auto extra = server_ctx->tokenizer->encode(continuation);
+            input_ids.reserve(extra.size() + 1);
+            input_ids.push_back(server_ctx->hot.transcript.back());
+            input_ids.insert(input_ids.end(), extra.begin(), extra.end());
+            server_ctx->hot.transcript.insert(server_ctx->hot.transcript.end(),
+                                               extra.begin(), extra.end());
+            caches = std::move(server_ctx->hot.caches);
+            server_ctx->hot.hits++;
+            std::cerr << "[session] hot Maple hit " << conversation_id << ": "
+                      << server_ctx->hot.transcript.size() << " tokens" << std::endl;
+        } else {
+            /* A cold recovery receives the complete browser transcript.  If a
+             * stateful document follow-up supplied recovery-only evidence,
+             * attach it once to the latest user turn before the full prefill. */
+            if (!pinned_context.empty()) {
+                for (auto it = msgs.rbegin(); it != msgs.rend(); ++it) {
+                    if (it->role == "user") {
+                        it->content += pinned_context;
+                        break;
+                    }
+                }
+            }
+            std::string prompt = server_ctx->tokenizer->apply_chat_template(
+                msgs, true, enable_thinking);
+            input_ids = server_ctx->tokenizer->encode(prompt);
+            caches = maple_new_caches(*server_ctx->model);
+        }
 
         std::vector<int> generated_tokens;
-        std::vector<KVCache*> caches;
-        for (const auto& layer_type : server_ctx->model->args().layer_types) {
-            if (layer_type == "sliding_attention") {
-                caches.push_back(new RotatingKVCache(server_ctx->model->args().sliding_window));
-            } else {
-                caches.push_back(new KVCache());
-            }
-        }
 
         bool client_connected = true;
         std::string streamed_text;
@@ -232,7 +348,26 @@ int samosa_maple_handler(SamosaHttpServer *server, int fd, const SamosaHttpReque
             generation_error = "unknown exception";
         }
 
-        for (auto* cache : caches) delete cache;
+        bool keep_hot = generation_error.empty() && client_connected &&
+                        max_tokens > 0 && !conversation_id.empty();
+        if (keep_hot) {
+            if (hot_hit) {
+                server_ctx->hot.transcript.insert(server_ctx->hot.transcript.end(),
+                                                   generated_tokens.begin(),
+                                                   generated_tokens.end());
+            } else {
+                server_ctx->hot.transcript = input_ids;
+            }
+            server_ctx->hot.caches = std::move(caches);
+            server_ctx->hot.conversation_id = conversation_id;
+            server_ctx->hot.valid = true;
+        } else {
+            for (auto* cache : caches) delete cache;
+            caches.clear();
+            if (hot_hit) maple_hot_evict(server_ctx->hot,
+                                         generation_error.empty()
+                                         ? "client disconnect" : "generation error");
+        }
 
         if (!generation_error.empty()) {
             std::cerr << "Maple generation failed: " << generation_error << std::endl;
@@ -423,7 +558,7 @@ int main(int argc, char** argv) {
         return 0;
     }
 
-    ServerContext ctx = {&model, &tokenizer};
+    ServerContext ctx(&model, &tokenizer);
 
     SamosaHttpServer server;
     if (!samosa_http_server_init(&server, port, samosa_maple_handler, &ctx)) {
@@ -433,6 +568,10 @@ int main(int argc, char** argv) {
 
     std::cout << "Maple HTTP Server running on http://127.0.0.1:" << port << std::endl;
     samosa_http_server_run(&server);
+    {
+        std::lock_guard<std::mutex> lock(ctx.inference_mutex);
+        maple_hot_evict(ctx.hot, "server shutdown");
+    }
     samosa_http_server_destroy(&server);
 
     return 0;

--- a/src/qwen36b.c
+++ b/src/qwen36b.c
@@ -3168,6 +3168,25 @@ typedef struct {
     double prefill_s, decode_s, total_s;
 } GenStats;
 
+/* One bounded live conversation.  The durable QWSESS01 file remains the
+ * recovery source of truth, but an active conversation no longer has to read,
+ * authenticate, allocate, and repopulate that file on every turn.  Model KV
+ * and recurrent arrays live in Model; this object owns the matching transcript
+ * and identifies which conversation those arrays belong to. */
+typedef struct {
+    char conversation_id[65];
+    char session_path[PATH_MAX];
+    int *tokens;
+    int len;
+    int capacity;
+    int valid;
+    int checkpointed;
+    double last_used;
+    uint64_t hits;
+    uint64_t restores;
+    uint64_t evictions;
+} ResidentSession;
+
 /* Server inference supplies a cooperative cancellation flag.  A monolithic
  * prefill otherwise cannot observe that flag until decode begins, which can
  * strand a timed-out background job for minutes.  Keep the established single
@@ -4199,6 +4218,76 @@ static void teacher_state_end(Model *m) {
     m->max_t=0;
 }
 
+/* GQA caches are laid out [head][capacity][head_dim], so changing capacity
+ * changes every head stride and cannot use realloc().  Grow into fresh arrays
+ * and copy only rows that have actually been stepped.  DeltaNet state has a
+ * fixed size and remains live unchanged. */
+static int teacher_state_grow(Model *m,int capacity,int used_rows){
+    if(!m||!m->K||capacity<=m->max_t)return 1;
+    if(used_rows<0||used_rows>m->max_t)return 0;
+    Cfg *c=&m->c;int old_capacity=m->max_t;
+    float **new_k=calloc((size_t)c->n_layers,sizeof(float *));
+    float **new_v=calloc((size_t)c->n_layers,sizeof(float *));
+    if(!new_k||!new_v){free(new_k);free(new_v);return 0;}
+    int ok=1;
+    for(int i=0;i<c->n_layers&&ok;i++)if(c->layer_type[i]==1){
+        size_t count=(size_t)c->n_kv_heads*(size_t)capacity*(size_t)c->head_dim;
+        new_k[i]=calloc(count,sizeof(float));new_v[i]=calloc(count,sizeof(float));
+        if(!new_k[i]||!new_v[i]){ok=0;break;}
+        for(int g=0;g<c->n_kv_heads;g++){
+            memcpy(new_k[i]+(int64_t)g*capacity*c->head_dim,
+                   m->K[i]+(int64_t)g*old_capacity*c->head_dim,
+                   (size_t)used_rows*c->head_dim*sizeof(float));
+            memcpy(new_v[i]+(int64_t)g*capacity*c->head_dim,
+                   m->V[i]+(int64_t)g*old_capacity*c->head_dim,
+                   (size_t)used_rows*c->head_dim*sizeof(float));
+        }
+    }
+    if(!ok){
+        for(int i=0;i<c->n_layers;i++){free(new_k[i]);free(new_v[i]);}
+        free(new_k);free(new_v);return 0;
+    }
+    for(int i=0;i<c->n_layers;i++)if(c->layer_type[i]==1){
+        free(m->K[i]);free(m->V[i]);m->K[i]=new_k[i];m->V[i]=new_v[i];
+    }
+    free(new_k);free(new_v);m->max_t=capacity;return 1;
+}
+
+static void resident_session_evict(Model *m,ResidentSession *resident,
+                                   const char *reason){
+    if(!resident||!resident->valid)return;
+    fprintf(stderr,"[session] evicted hot conversation %s (%s, %d tokens)\n",
+            resident->conversation_id,
+            reason&&*reason?reason:"policy",resident->len);
+    free(resident->tokens);resident->tokens=NULL;
+    teacher_state_end(m);
+    resident->valid=0;resident->checkpointed=0;resident->len=0;
+    resident->capacity=0;resident->conversation_id[0]=0;
+    resident->session_path[0]=0;resident->last_used=0;resident->evictions++;
+}
+
+static int resident_session_matches(const ResidentSession *resident,
+                                    const char *session_path){
+    return resident&&resident->valid&&session_path&&
+           !strcmp(resident->session_path,session_path);
+}
+
+/* Available memory already excludes the resident cache. A no-growth hot turn
+ * therefore needs no second charge for existing rows. A grow is different:
+ * the new stride-adjusted arrays briefly coexist with the old cache. */
+static int resident_growth_memory_fits(const Model *m,int capacity){
+    const double reserve_bytes=512.0*1024.0*1024.0;
+    if(!m||capacity<0)return 0;
+    /* Growing changes the per-head stride, so fresh arrays coexist with the
+     * old arrays until the copy completes. Charge the complete destination
+     * capacity for that short transition; once copied, the old cache is
+     * released and available memory rises again. */
+    int additional=capacity>m->max_t?capacity:0;
+    if((uint64_t)additional>UINT64_MAX/m->kv_bytes_per_token)return 0;
+    double required=(double)((uint64_t)additional*m->kv_bytes_per_token)+reserve_bytes;
+    return required<=mem_available_gb()*1e9;
+}
+
 static int *read_int_array(jval *o, const char *key, int *n_out) {
     jval *a = json_get(o, key);
     int *r = malloc(a->len * sizeof(int));
@@ -4485,7 +4574,7 @@ static int run_chat(Model *m, const char *tokenizer_path, const char *user,
                     const char *resume_session, int resume_decode,
                     Tok *shared_tokenizer,
                     TokenSink output_sink, void *output_ctx,
-                    GenStats *stats_out) {
+                    GenStats *stats_out,ResidentSession *resident) {
     Tok local_tokenizer;
     Tok *tok=shared_tokenizer;
     if(!tok){ tok=&local_tokenizer; tok_load(tok,tokenizer_path); }
@@ -4527,12 +4616,18 @@ static int run_chat(Model *m, const char *tokenizer_path, const char *user,
     GenStats stats={0};
     int *transcript = NULL; int final_len = 0; int np = 0;
 
+    int resident_hit=resident_session_matches(resident,resume_session);
     if (resume_session) {
         if (resume_decode > 0) n_new = resume_decode;
         int *extra = NULL; int n_extra = 0;
         char *cont_text = NULL;
         int hlen_hint=0,last_hint=-1;
-        if(!session_peek(m,resume_session,&hlen_hint,&last_hint)){
+        if(resident_hit){
+            hlen_hint=resident->len;last_hint=resident->tokens[resident->len-1];
+            resident->hits++;
+            fprintf(stderr,"[session] hot hit %s: %d tokens\n",
+                    resident->conversation_id,resident->len);
+        }else if(!session_peek(m,resume_session,&hlen_hint,&last_hint)){
             fprintf(stderr,"session: invalid header: %s\n",resume_session);
             return 1;
         }
@@ -4553,13 +4648,31 @@ static int run_chat(Model *m, const char *tokenizer_path, const char *user,
                     m->context_limit);
             free(extra);free(cont_text);return 1;
         }
-        if(!context_memory_fits(m,hlen_hint+n_extra+n_new)){
+        int needed=hlen_hint+n_extra+n_new;
+        int memory_ok=resident_hit?resident_growth_memory_fits(m,needed):
+                                   context_memory_fits(m,needed);
+        if(!memory_ok){
             fprintf(stderr,"session: insufficient available memory for %d-token context\n",
-                    hlen_hint+n_extra+n_new);
+                    needed);
             free(extra);free(cont_text);return 1;
         }
-        int hlen=0;
-        int *hist=session_resume(m,resume_session,n_extra+n_new,&hlen);
+        int hlen=0;int *hist=NULL;
+        if(resident_hit){
+            hlen=resident->len;
+            if(!teacher_state_grow(m,needed,hlen-1)){
+                fprintf(stderr,"session: OOM growing hot KV state to %d tokens\n",needed);
+                free(extra);free(cont_text);return 1;
+            }
+            int *grown=realloc(resident->tokens,(size_t)needed*sizeof(int));
+            if(!grown){
+                fprintf(stderr,"session: OOM growing hot transcript\n");
+                free(extra);free(cont_text);return 1;
+            }
+            resident->tokens=grown;resident->capacity=needed;hist=grown;
+        }else{
+            hist=session_resume(m,resume_session,n_extra+n_new,&hlen);
+            if(resident)resident->restores++;
+        }
         if (!output_sink) {
             printf("%s", "\n");
             fflush(stdout);
@@ -4674,13 +4787,41 @@ static int run_chat(Model *m, const char *tokenizer_path, const char *user,
     if (m->seq_reads)
         fprintf(stderr,"[seqio] layer_reads=%llu bytes=%.2f GB\n",
                 (unsigned long long)m->seq_reads,(double)m->seq_bytes/1e9);
+    int keep_resident=resident&&save_session&&!stats.session_save_skipped&&
+                      !stats.session_save_failed&&save_len==final_len;
+    if(keep_resident){
+        resident->tokens=transcript;resident->len=save_len;
+        resident->capacity=m->max_t;resident->valid=1;resident->checkpointed=1;
+        resident->last_used=now_s();
+        snprintf(resident->session_path,sizeof(resident->session_path),"%s",save_session);
+        const char *slash=strrchr(save_session,'/');
+        if(slash){
+            size_t directory=(size_t)(slash-save_session);
+            const char *start=save_session;
+            const char *previous=NULL;
+            for(const char *p=save_session;p<slash;p++)if(*p=='/')previous=p;
+            if(previous)start=previous+1;
+            size_t length=(size_t)(slash-start);
+            if(length>=sizeof(resident->conversation_id))length=sizeof(resident->conversation_id)-1;
+            memcpy(resident->conversation_id,start,length);resident->conversation_id[length]=0;
+            (void)directory;
+        }
+        transcript=NULL;
+    }
     free(transcript);
     if (stats_out) *stats_out=stats;
     if (options) {
         free(options->seen);
         options->seen=NULL;
     }
-    teacher_state_end(m);
+    if(!keep_resident){
+        if(resident&&resident->valid&&resident_hit){
+            resident->tokens=NULL;resident->valid=0;resident->checkpointed=0;
+            resident->len=0;resident->capacity=0;resident->conversation_id[0]=0;
+            resident->session_path[0]=0;resident->last_used=0;resident->evictions++;
+        }
+        teacher_state_end(m);
+    }
 #ifdef __APPLE__
     /* Multi-eviction admissions can leave surplus reusable expert slabs even
      * though the live cache payload is flat. Scratch already owns up to 64
@@ -4807,6 +4948,7 @@ static void serve_scheduler_release(ServeScheduler *scheduler){
 
 typedef struct {
     Model *model;
+    ResidentSession resident;
     Tok tokenizer;
     const char *tokenizer_path;
     const char *snapshot;
@@ -4822,12 +4964,48 @@ typedef struct {
     int compact_threshold_percent;
     double started;
     int port;
+    int resident_idle_seconds;
+    int resident_min_available_mb;
+    pthread_t resident_reaper_thread;
+    int resident_reaper_started;
     /* Jobs system: track interactive request state for /internal/v1/status */
     pthread_mutex_t interactive_mu;
     int interactive_active;    /* 1 while a non-background request holds the slot */
     double last_interactive_ts; /* monotonic timestamp of last interactive completion */
     int current_request_background; /* set per-request from X-Samosa-Priority header */
 } SamosaServeContext;
+
+static int serve_scheduler_try_idle(ServeScheduler *scheduler){
+    int acquired=0;pthread_mutex_lock(&scheduler->mu);
+    if(!scheduler->stopping&&!scheduler->active&&!scheduler->waiting){
+        scheduler->active=1;acquired=1;
+    }
+    pthread_mutex_unlock(&scheduler->mu);return acquired;
+}
+
+static void *resident_session_reaper(void *opaque){
+    SamosaServeContext *ctx=(SamosaServeContext *)opaque;
+    const struct timespec pause={.tv_sec=1,.tv_nsec=0};
+    for(;;){
+        nanosleep(&pause,NULL);
+        pthread_mutex_lock(&ctx->scheduler.mu);
+        int stopping=ctx->scheduler.stopping;
+        pthread_mutex_unlock(&ctx->scheduler.mu);
+        if(stopping)break;
+        if(!serve_scheduler_try_idle(&ctx->scheduler))continue;
+        if(ctx->resident.valid){
+            double idle=now_s()-ctx->resident.last_used;
+            double available_mb=mem_available_gb()*1000.0;
+            if(ctx->resident_idle_seconds>0&&idle>=ctx->resident_idle_seconds)
+                resident_session_evict(ctx->model,&ctx->resident,"idle timeout");
+            else if(ctx->resident_min_available_mb>0&&
+                    available_mb<ctx->resident_min_available_mb)
+                resident_session_evict(ctx->model,&ctx->resident,"memory pressure");
+        }
+        serve_scheduler_release(&ctx->scheduler);
+    }
+    return NULL;
+}
 
 static int serve_static_file(int fd,const char *path,const char *content_type,
                              const char *extra){
@@ -4841,6 +5019,31 @@ static int serve_static_file(int fd,const char *path,const char *content_type,
     if(ok)ok=samosa_http_headers(fd,200,content_type,length,extra)&&
              (!length||samosa_send_all(fd,data,length));
     free(data);return ok;
+}
+
+static int serve_valid_id(const char *id);
+
+static char *serve_document_context_load(SamosaServeContext *ctx,
+                                         const char *conversation_id){
+    if(!ctx||!serve_valid_id(conversation_id))return NULL;
+    char path[PATH_MAX];
+    if(snprintf(path,sizeof(path),"%s/%s/document-context.txt",
+                ctx->chats_dir,conversation_id)>=(int)sizeof(path))return NULL;
+    int fd=open(path,O_RDONLY|O_NOFOLLOW);if(fd<0)return NULL;
+    struct stat st;
+    if(fstat(fd,&st)||!S_ISREG(st.st_mode)||st.st_size<1||st.st_size>262144){
+        close(fd);return NULL;
+    }
+    size_t length=(size_t)st.st_size;char *data=malloc(length+1);
+    if(!data){close(fd);return NULL;}
+    size_t used=0;
+    while(used<length){
+        ssize_t got=read(fd,data+used,length-used);
+        if(got<0&&errno==EINTR)continue;
+        if(got<=0){free(data);close(fd);return NULL;}
+        used+=(size_t)got;
+    }
+    close(fd);data[length]=0;return data;
 }
 
 typedef struct {
@@ -4863,6 +5066,43 @@ static int serve_sse_piece(ServeTokenSink *sink,const char *field,
         serve_buffer_append(&event,suffix,strlen(suffix));
     if(ok)ok=samosa_send_all(sink->fd,event.data,event.length);
     free(event.data); return ok;
+}
+
+static int serve_context_activity(int fd,const char *stage,const char *message,
+                                  int progress,int indeterminate){
+    ServeBuffer event={0};char number[32];
+    snprintf(number,sizeof(number),"%d",progress);
+    int ok=serve_buffer_append(&event,
+        "data: {\"choices\":[{\"index\":0,\"delta\":{\"file_activity\":{"
+        "\"filename\":\"Conversation context\",\"stage\":\"",
+        strlen("data: {\"choices\":[{\"index\":0,\"delta\":{\"file_activity\":{"
+               "\"filename\":\"Conversation context\",\"stage\":\""))&&
+        serve_json_escape(&event,stage,strlen(stage))&&
+        serve_buffer_append(&event,"\",\"message\":\"",strlen("\",\"message\":\""))&&
+        serve_json_escape(&event,message,strlen(message))&&
+        serve_buffer_append(&event,"\",\"progress\":",strlen("\",\"progress\":"))&&
+        serve_buffer_append(&event,number,strlen(number))&&
+        serve_buffer_append(&event,indeterminate?
+            ",\"indeterminate\":true}}},\"finish_reason\":null}]}\n\n":
+            ",\"indeterminate\":false}}},\"finish_reason\":null}]}\n\n",
+            strlen(indeterminate?
+            ",\"indeterminate\":true}}},\"finish_reason\":null}]}\n\n":
+            ",\"indeterminate\":false}}},\"finish_reason\":null}]}\n\n"));
+    if(ok)ok=samosa_send_all(fd,event.data,event.length);
+    free(event.data);return ok;
+}
+
+static int serve_stream_error(int fd,const char *code,const char *message){
+    ServeBuffer event={0};
+    int ok=serve_buffer_append(&event,"data: {\"error\":{\"code\":\"",
+                               strlen("data: {\"error\":{\"code\":\""))&&
+        serve_json_escape(&event,code,strlen(code))&&
+        serve_buffer_append(&event,"\",\"message\":\"",strlen("\",\"message\":\""))&&
+        serve_json_escape(&event,message,strlen(message))&&
+        serve_buffer_append(&event,"\"}}\n\ndata: [DONE]\n\n",
+                            strlen("\"}}\n\ndata: [DONE]\n\n"));
+    if(ok)ok=samosa_send_all(fd,event.data,event.length);
+    free(event.data);return ok;
 }
 
 static int serve_token_sink(int token,void *opaque){
@@ -5021,7 +5261,7 @@ static int compact_session(SamosaServeContext *ctx,const char *session_path,
     GenStats summary_stats={0};
     int failed=run_chat(ctx->model,ctx->tokenizer_path,instruction,NULL,
         summary_tokens,1,0,&options,NULL,session_path,0,&ctx->tokenizer,
-        serve_token_sink,&summary,&summary_stats);
+        serve_token_sink,&summary,&summary_stats,NULL);
     if(failed||summary_stats.cancelled||!summary.content.length){
         free(summary.reasoning.data);free(summary.content.data);free(old_tokens);
         return 0;
@@ -5200,12 +5440,16 @@ static int serve_context_measure(SamosaServeContext *ctx,const char *user,
  * product cap, and -1 for an unreadable/incompatible saved session. */
 static int serve_context_preflight(SamosaServeContext *ctx,const char *user,
                                    const char *system,int no_thinking,
-                                   const char *resume_session,int generated){
+                                   const char *resume_session,int generated,
+                                   const ResidentSession *resident){
     int existing=0,extra=0;
     if(serve_context_measure(ctx,user,system,no_thinking,resume_session,
                              &existing,&extra)<0)return -1;
     if(!context_fits(ctx->model,existing,extra,generated))return 0;
-    return context_memory_fits(ctx->model,existing+extra+generated)?1:-2;
+    int total=existing+extra+generated;
+    return resident_session_matches(resident,resume_session)
+        ? (resident_growth_memory_fits(ctx->model,total)?1:-2)
+        : (context_memory_fits(ctx->model,total)?1:-2);
 }
 
 static int serve_finish_reason(const GenStats *stats,const char **closure){
@@ -5315,6 +5559,7 @@ static int samosa_serve_chat(SamosaServeContext *ctx,int fd,jval *root){
     options.cancel_flag=&ctx->cancel;
 
     char session_path[PATH_MAX]={0}; const char *save_session=NULL,*resume_session=NULL;
+    const char *conversation_id=NULL;
     value=serve_json_field(root,"conversation_id",J_STR);
     if(value){
         if(!serve_valid_id(value->str))return samosa_http_json_error(fd,400,
@@ -5325,6 +5570,7 @@ static int samosa_serve_chat(SamosaServeContext *ctx,int fd,jval *root){
            snprintf(session_path,sizeof(session_path),"%s/session.qws",directory)>=(int)sizeof(session_path))
             return samosa_http_json_error(fd,500,"session_path_failed","Unable to create conversation storage.");
         save_session=session_path; if(!access(session_path,R_OK))resume_session=session_path;
+        conversation_id=value->str;
     }
 
     int existing=0,extra=0;
@@ -5335,8 +5581,11 @@ static int samosa_serve_chat(SamosaServeContext *ctx,int fd,jval *root){
     int auto_candidate=ctx->auto_compact&&resume_session&&
         compaction_should_run(existing,extra,max_tokens,ctx->model->context_limit,
                               ctx->compact_threshold_percent);
-    int context_ok=auto_candidate?1:serve_context_preflight(ctx,user,system,no_thinking,
-                                                            resume_session,max_tokens);
+    /* Memory is rechecked after exclusive model admission.  Before that point
+     * a currently running turn may still be growing or replacing the hot
+     * state, so only the stable snapshot header is safe to inspect here. */
+    int context_ok=auto_candidate?1:
+        (context_fits(ctx->model,existing,extra,max_tokens)?1:0);
     if(context_ok==-2){ free(user); return samosa_http_json_error(fd,503,"insufficient_memory",
         "Not enough currently available memory for this context window."); }
     if(context_ok<0){ free(user); return samosa_http_json_error(fd,409,"invalid_session",
@@ -5353,6 +5602,13 @@ static int samosa_serve_chat(SamosaServeContext *ctx,int fd,jval *root){
         ctx->interactive_active=1;
         pthread_mutex_unlock(&ctx->interactive_mu);
     }
+    /* Model state can belong to only one conversation.  Every completed hot
+     * turn is already atomically checkpointed, so switching (or a stateless
+     * control request) can drop it without losing durable history. */
+    if(ctx->resident.valid&&
+       (!save_session||strcmp(ctx->resident.session_path,session_path)))
+        resident_session_evict(ctx->model,&ctx->resident,
+                               save_session?"conversation switch":"stateless request");
     /* A queued request for the same conversation may have created or replaced
      * the snapshot while this request waited. Refresh and revalidate while we
      * hold exclusive model admission, before allocation or response headers. */
@@ -5366,24 +5622,59 @@ static int samosa_serve_chat(SamosaServeContext *ctx,int fd,jval *root){
         compaction_should_run(existing,extra,max_tokens,ctx->model->context_limit,
                               ctx->compact_threshold_percent);
     CompactionResult compaction={0};
+    int response_started=0;
     if(auto_candidate){
+        if(stream){
+            response_started=samosa_http_stream_headers(fd)&&
+                serve_context_activity(fd,"compacting",
+                    "Optimizing the conversation context locally before answering…",
+                    25,1);
+            if(!response_started){
+                serve_scheduler_release(&ctx->scheduler);free(user);return 0;
+            }
+        }
+        if(ctx->resident.valid)
+            resident_session_evict(ctx->model,&ctx->resident,"automatic compaction");
         atomic_store(&ctx->cancel,0);
-        if(!compact_session(ctx,resume_session,pinned_context,&compaction)){
+        char *saved_pinned=NULL;
+        const char *effective_pinned=pinned_context;
+        if(!effective_pinned&&conversation_id){
+            saved_pinned=serve_document_context_load(ctx,conversation_id);
+            effective_pinned=saved_pinned;
+        }
+        int compacted=compact_session(ctx,resume_session,effective_pinned,&compaction);
+        free(saved_pinned);
+        if(!compacted){
             serve_scheduler_release(&ctx->scheduler);free(user);
+            if(response_started){
+                serve_stream_error(fd,"compaction_failed",
+                    "Automatic compaction could not safely replace the saved session.");
+                return 1;
+            }
             return samosa_http_json_error(fd,500,"compaction_failed",
                 "Automatic compaction could not safely replace the saved session. "
                 "The original session was kept unchanged.");}
         resume_session=session_path;
+        if(response_started&&!serve_context_activity(fd,"compacted",
+            "Conversation context optimized. Answering now…",75,0)){
+            serve_scheduler_release(&ctx->scheduler);free(user);return 0;
+        }
     }
     context_ok=serve_context_preflight(ctx,user,system,no_thinking,
-                                       resume_session,max_tokens);
+                                       resume_session,max_tokens,&ctx->resident);
     if(context_ok==-2){serve_scheduler_release(&ctx->scheduler); free(user);
+        if(response_started){serve_stream_error(fd,"insufficient_memory",
+            "Not enough currently available memory for this context window.");return 1;}
         return samosa_http_json_error(fd,503,"insufficient_memory",
             "Not enough currently available memory for this context window.");}
     if(context_ok<0){serve_scheduler_release(&ctx->scheduler); free(user);
+        if(response_started){serve_stream_error(fd,"invalid_session",
+            "The saved conversation is invalid or incompatible with this model.");return 1;}
         return samosa_http_json_error(fd,409,"invalid_session",
             "The saved conversation header is invalid or incompatible with this model.");}
     if(!context_ok){serve_scheduler_release(&ctx->scheduler); free(user);
+        if(response_started){serve_stream_error(fd,"context_limit",
+            "This turn would exceed Samosa Chat's configured context limit.");return 1;}
         return samosa_http_json_error(fd,400,"context_limit",
             "This turn could exceed Samosa Chat's configured total context limit. "
             "Start a new chat, shorten the message, or request fewer output tokens.");}
@@ -5392,11 +5683,11 @@ static int samosa_serve_chat(SamosaServeContext *ctx,int fd,jval *root){
         .close_token=tok_id_of(&ctx->tokenizer,"</think>"),.tokenizer=&ctx->tokenizer,
         .eos_token=tok_id_of(&ctx->tokenizer,"<|im_end|>"),
         .eot_token=tok_id_of(&ctx->tokenizer,"<|endoftext|>"),.cancel=&ctx->cancel};
-    int sent=stream?samosa_http_stream_headers(fd):1;
+    int sent=stream?(response_started?1:samosa_http_stream_headers(fd)):1;
     GenStats stats={0}; int result=1;
     if(sent)result=run_chat(ctx->model,ctx->tokenizer_path,user,system,max_tokens,
         no_thinking,1,&options,save_session,resume_session,0,&ctx->tokenizer,
-        serve_token_sink,&sink,&stats);
+        serve_token_sink,&sink,&stats,&ctx->resident);
     if(compaction.before_tokens){
         stats.compacted=1;
         stats.compacted_from_tokens=compaction.before_tokens;
@@ -5443,6 +5734,8 @@ static int samosa_serve_settings(SamosaServeContext *ctx,int fd,jval *root){
     int admitted=serve_scheduler_acquire(&ctx->scheduler,NULL,0);
     if(admitted==0)return samosa_http_json_error(fd,429,"queue_full","The inference queue is full.");
     if(admitted<0)return samosa_http_json_error(fd,503,"shutting_down","Samosa is shutting down.");
+    if(ctx->resident.valid)
+        resident_session_evict(ctx->model,&ctx->resident,"runtime settings change");
     int ok=!has_context||model_configure_context_limit(ctx->model,spec);
     if(ok&&auto_value)ctx->auto_compact=auto_value->boolean;
     if(ok&&threshold_value)ctx->compact_threshold_percent=(int)threshold_value->num;
@@ -5476,11 +5769,19 @@ static int samosa_serve_compact(SamosaServeContext *ctx,int fd,jval *root){
     if(access(path,R_OK)){serve_scheduler_release(&ctx->scheduler);
         return samosa_http_json_error(fd,404,"session_not_found",
             "This conversation does not have a saved session to compact.");}
+    if(ctx->resident.valid)
+        resident_session_evict(ctx->model,&ctx->resident,"manual compaction");
     atomic_store(&ctx->cancel,0);
     CompactionResult compacted={0};
     jval *pinned_value=serve_json_field(root,"pinned_context",J_STR);
     const char *pinned_context=pinned_value?pinned_value->str:NULL;
+    char *saved_pinned=NULL;
+    if(!pinned_context){
+        saved_pinned=serve_document_context_load(ctx,conversation->str);
+        pinned_context=saved_pinned;
+    }
     int ok=compact_session(ctx,path,pinned_context,&compacted);
+    free(saved_pinned);
     serve_scheduler_release(&ctx->scheduler);
     if(!ok)return samosa_http_json_error(fd,500,"compaction_failed",
         "Compaction could not safely replace the saved session. "
@@ -5545,21 +5846,35 @@ static int samosa_serve_handler(SamosaHttpServer *server,int fd,
     if(!strcmp(request->method,"GET")&&!strcmp(request->path,"/healthz")){
         GenStats stats={0};int has;
         pthread_mutex_lock(&ctx->stats_mu);stats=ctx->last_stats;has=ctx->has_last_stats;pthread_mutex_unlock(&ctx->stats_mu);
-        pthread_mutex_lock(&ctx->scheduler.mu);int active=ctx->scheduler.active,queued=ctx->scheduler.waiting;pthread_mutex_unlock(&ctx->scheduler.mu);
+        pthread_mutex_lock(&ctx->scheduler.mu);
+        int active=ctx->scheduler.active,queued=ctx->scheduler.waiting;
+        int resident_hot=!active&&ctx->resident.valid;
+        int resident_tokens=resident_hot?ctx->resident.len:0;
+        uint64_t resident_hits=!active?ctx->resident.hits:0;
+        uint64_t resident_restores=!active?ctx->resident.restores:0;
+        uint64_t resident_evictions=!active?ctx->resident.evictions:0;
+        pthread_mutex_unlock(&ctx->scheduler.mu);
         int model_limit=ctx->model?ctx->model->model_context_limit:SAMOSA_LEGACY_CONTEXT_TOKENS;
         int context_limit=ctx->model?ctx->model->context_limit:SAMOSA_LEGACY_CONTEXT_TOKENS;
         uint64_t kv_per_token=ctx->model?ctx->model->kv_bytes_per_token:0;
         const char *context_mode=ctx->model&&ctx->model->context_limit_is_auto?"auto":"manual";
-        char body[1152];snprintf(body,sizeof(body),
+        char body[1792];snprintf(body,sizeof(body),
             "{\"status\":\"ok\",\"model\":\"qwen3.6-35b-a3b\",\"rss_gb\":%.2f,"
             "\"model_context_limit_tokens\":%d,\"context_limit_tokens\":%d,"
             "\"context_limit_mode\":\"%s\",\"kv_bytes_per_token\":%llu,\"uptime_seconds\":%.0f,"
             "\"compaction\":{\"auto\":%s,\"threshold_percent\":%d},"
+            "\"resident_session\":{\"capacity\":1,\"hot\":%s,\"tokens\":%d,"
+            "\"idle_evict_seconds\":%d,\"min_available_mb\":%d,"
+            "\"hits\":%llu,\"restores\":%llu,\"evictions\":%llu},"
             "\"scheduler\":{\"active\":%s,\"queued\":%d,"
             "\"max_queue\":%d},\"last_generation\":{\"available\":%s,"
             "\"tokens\":%d,\"tokens_per_second\":%.2f}}",rss_gb(),
             model_limit,context_limit,context_mode,(unsigned long long)kv_per_token,now_s()-ctx->started,
             ctx->auto_compact?"true":"false",ctx->compact_threshold_percent,
+            resident_hot?"true":"false",resident_tokens,
+            ctx->resident_idle_seconds,ctx->resident_min_available_mb,
+            (unsigned long long)resident_hits,(unsigned long long)resident_restores,
+            (unsigned long long)resident_evictions,
             active?"true":"false",queued,ctx->scheduler.max_waiting,has?"true":"false",
             stats.generated,stats.generated>1&&stats.decode_s>0?(stats.generated-1)/stats.decode_s:0);
         return samosa_http_response(fd,200,"application/json",body,NULL);
@@ -5641,7 +5956,8 @@ static int run_samosa_serve(Model *model,const char *snapshot,
                             const char *tokenizer_path,int port,int max_queue){
     SamosaServeContext context={.model=model,.tokenizer_path=tokenizer_path,
         .snapshot=snapshot,.auto_compact=1,.compact_threshold_percent=80,
-        .started=now_s(),.port=port};
+        .started=now_s(),.port=port,.resident_idle_seconds=300,
+        .resident_min_available_mb=768};
     /* The compiled gateway persists these Advanced settings and injects them
      * before launch.  Reading them here keeps compaction policy durable across
      * backend restarts instead of silently resetting to on/80 every time. */
@@ -5654,6 +5970,16 @@ static int run_samosa_serve(Model *model,const char *snapshot,
         char *end=NULL;long value=strtol(threshold,&end,10);
         if(end&&!*end&&value>=50&&value<=90)
             context.compact_threshold_percent=(int)value;
+    }
+    const char *resident_idle=getenv("SAMOSA_HOT_SESSION_IDLE_SECONDS");
+    if(resident_idle&&*resident_idle){
+        char *end=NULL;long value=strtol(resident_idle,&end,10);
+        if(end&&!*end&&value>=0&&value<=86400)context.resident_idle_seconds=(int)value;
+    }
+    const char *resident_floor=getenv("SAMOSA_HOT_SESSION_MIN_AVAILABLE_MB");
+    if(resident_floor&&*resident_floor){
+        char *end=NULL;long value=strtol(resident_floor,&end,10);
+        if(end&&!*end&&value>=0&&value<=65536)context.resident_min_available_mb=(int)value;
     }
     atomic_init(&context.cancel,0);pthread_mutex_init(&context.stats_mu,NULL);
     pthread_mutex_init(&context.interactive_mu,NULL);
@@ -5673,7 +5999,16 @@ static int run_samosa_serve(Model *model,const char *snapshot,
     g_signal_server=&server;g_signal_context=&context;signal(SIGINT,samosa_serve_signal);signal(SIGTERM,samosa_serve_signal);
     fprintf(stderr,"[serve] ready http://127.0.0.1:%d queue=%d chats=%s\n",
         server.port,max_queue,context.chats_dir);fflush(stderr);
+    if(!pthread_create(&context.resident_reaper_thread,NULL,
+                       resident_session_reaper,&context))
+        context.resident_reaper_started=1;
+    else fprintf(stderr,"[session] warning: hot-session idle reaper unavailable\n");
     int ok=samosa_http_server_run(&server);
+    pthread_mutex_lock(&context.scheduler.mu);context.scheduler.stopping=1;
+    pthread_cond_broadcast(&context.scheduler.cv);pthread_mutex_unlock(&context.scheduler.mu);
+    if(context.resident_reaper_started)pthread_join(context.resident_reaper_thread,NULL);
+    if(context.resident.valid)
+        resident_session_evict(context.model,&context.resident,"server shutdown");
     samosa_http_server_destroy(&server);tok_free(&context.tokenizer);
     pthread_mutex_destroy(&context.stats_mu);pthread_mutex_destroy(&context.interactive_mu);
     pthread_cond_destroy(&context.scheduler.cv);
@@ -6191,7 +6526,7 @@ int main(int argc, char **argv) {
         if(!model_configure_context_limit(&m,context_spec))return 2;
         return run_chat(&m, tokenizer_path, chat, system, n_chat, no_thinking, stream,&options,
                         cli_save_session, cli_resume_session, cli_resume_decode,
-                        NULL, NULL, NULL, NULL);
+                        NULL, NULL, NULL, NULL, NULL);
     }
     
     if (snap) {

--- a/src/samosa_gateway.c
+++ b/src/samosa_gateway.c
@@ -7313,6 +7313,70 @@ static int conversation_documents_path(Gateway *g, const char *id,
            path_join(out, cap, dir, "documents.json");
 }
 
+/* The manifest records identity and extraction mode; this sidecar records the
+ * exact bounded evidence already admitted to the model.  Keeping it beside the
+ * conversation lets every text backend reuse a stable prompt prefix without
+ * re-running OCR or query-specific assembly on ordinary full-document
+ * follow-ups.  It is local private conversation state, never a public asset. */
+static int conversation_document_context_path(Gateway *g,const char *id,
+                                              char *out,size_t cap){
+    char chats[PATH_MAX],dir[PATH_MAX];
+    return valid_conversation_id(id)&&
+           path_join(chats,sizeof(chats),g->home,"chats")&&
+           path_join(dir,sizeof(dir),chats,id)&&
+           path_join(out,cap,dir,"document-context.txt");
+}
+
+static char *conversation_document_context_load(Gateway *g,const char *id){
+    char path[PATH_MAX];
+    if(!conversation_document_context_path(g,id,path,sizeof(path)))return NULL;
+    return read_file_limit(path,262144);
+}
+
+static int conversation_document_context_exists(Gateway *g,const char *id){
+    char path[PATH_MAX];
+    return conversation_document_context_path(g,id,path,sizeof(path))&&
+           access(path,R_OK)==0;
+}
+
+static int conversation_document_context_append(Gateway *g,const char *id,
+                                                TextBuffer *out){
+    char *saved=conversation_document_context_load(g,id);
+    if(!saved)return 0;
+    int ok=text_add(out,saved);free(saved);return ok;
+}
+
+static int conversation_document_context_save(Gateway *g,const char *id,
+                                              const char *context){
+    char path[PATH_MAX],chats[PATH_MAX],dir[PATH_MAX];
+    if(!context||!*context||strlen(context)>262144||
+       !path_join(chats,sizeof(chats),g->home,"chats")||
+       !path_join(dir,sizeof(dir),chats,id)||!mkdirs(dir)||
+       !conversation_document_context_path(g,id,path,sizeof(path)))return 0;
+    return write_small_file(path,context);
+}
+
+static void conversation_document_context_invalidate(Gateway *g,const char *id){
+    char path[PATH_MAX];
+    if(conversation_document_context_path(g,id,path,sizeof(path)))unlink(path);
+}
+
+static int conversation_documents_all_full(const ConversationDocuments *docs){
+    if(!docs||docs->len<1)return 0;
+    for(int i=0;i<docs->len;i++)if(strcmp(docs->items[i].mode,"full"))return 0;
+    return 1;
+}
+
+static int conversation_documents_full_context_current(
+        Gateway *g,const ConversationDocuments *docs){
+    if(!conversation_documents_all_full(docs))return 0;
+    const char *fingerprint=reader_fingerprint(g);
+    for(int i=0;i<docs->len;i++)
+        if(!docs->items[i].extractor_fingerprint[0]||
+           strcmp(docs->items[i].extractor_fingerprint,fingerprint))return 0;
+    return 1;
+}
+
 static int conversation_documents_lock(Gateway *g, const char *id,
                                        int *lock_out) {
     char chats[PATH_MAX], dir[PATH_MAX], lock_path[PATH_MAX];
@@ -7506,6 +7570,10 @@ static int conversation_documents_handler(Gateway *g, int fd,
         if (!removed)
             return samosa_http_json_error(fd, 404, "conversation_document_not_found",
                                           "That document is not attached to this conversation.");
+        /* The saved evidence may contain the detached document.  Invalidate it
+         * immediately; a later turn can rebuild the remaining set from the
+         * extraction cache without exposing stale detached text. */
+        conversation_document_context_invalidate(g,id);
         return samosa_http_response(fd, 200, "application/json", "{\"deleted\":true}", NULL);
     }
     return samosa_http_json_error(fd, 405, "method_not_allowed",
@@ -12720,10 +12788,21 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
                           message, 15, 1);
     }
 
-    int reuse_saved_document_context =
-        !have_attachments && have_bound_documents && !strcmp(g->backend, "qwen") &&
-        conversation_id && conversation_session_exists(g, conversation_id) &&
+    int saved_context_current=have_bound_documents&&
+        conversation_documents_full_context_current(g,&bound_documents)&&
+        conversation_document_context_exists(g,conversation_id);
+    int native_conversation_state=!strcmp(g->backend,"qwen")||
+                                  !strcmp(g->backend,"maple");
+    int prompt_prefix_cache=!strcmp(g->backend,"bonsai")||
+                            !strcmp(g->backend,"ornith");
+    int reuse_saved_document_context=
+        !have_attachments&&saved_context_current&&native_conversation_state&&
+        conversation_id&&(!strcmp(g->backend,"maple")||
+        conversation_session_exists(g,conversation_id))&&
         !vision_turn.plan.inspect_visual;
+    int reuse_stable_document_prefix=
+        !have_attachments&&saved_context_current&&prompt_prefix_cache&&
+        conversation_id&&!vision_turn.plan.inspect_visual;
     int document_progress = streaming &&
         (have_document_attachments || have_bound_documents);
     if (document_progress && !web_progress.started &&
@@ -12736,8 +12815,15 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
                                bound_documents.len ? bound_documents.items[0].filename :
                                "Attached document";
         char message[320];
-        snprintf(message, sizeof(message), "Reading %s with Samosa's local file reader…", filename);
-        file_sse_activity(&web_progress, filename, "reading", message, 15, 0);
+        const char *stage="reading";
+        if(reuse_saved_document_context||reuse_stable_document_prefix){
+            snprintf(message,sizeof(message),"Using the already extracted text from %s…",filename);
+            stage="reused";
+        }else if(!have_attachments&&have_bound_documents){
+            snprintf(message,sizeof(message),"Searching the previously extracted text from %s…",filename);
+            stage="searching";
+        }else snprintf(message,sizeof(message),"Reading %s with Samosa's local file reader…",filename);
+        file_sse_activity(&web_progress,filename,stage,message,15,0);
     }
 
     /* Molmo2 was trained to receive multiple visual placeholders in one
@@ -12794,13 +12880,13 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
             }
     }
     if (reuse_saved_document_context) {
-        /* The Qwen session already contains the previous turn's exact file
-           passages. Re-inserting them here forces another 1K+ token native
-           prefill on every follow-up, defeating the point of the saved KV
-           session. Keep a small continuity marker in the new user turn; the
-           full extracted evidence is rebuilt below only for pinned compaction
-           context. If no session exists, the normal extraction path remains
-           the safe fallback. */
+        /* The native Qwen/Maple session already contains the previous turn's
+           exact file passages. Re-inserting them here forces another 1K+
+           token native prefill on every follow-up, defeating the point of the
+           saved K/V session. Keep a small continuity marker in the new user
+           turn; the full extracted evidence is loaded below only for cold
+           recovery or compaction. If no usable state exists, the normal
+           extraction path remains the safe fallback. */
         text_add(&doc_evidence,
             "\n\n--- Attached document context already loaded in this conversation ---\n"
             "The preceding saved conversation turn contains the exact passages "
@@ -12817,7 +12903,14 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
             file_sse_activity(&web_progress, filename, "reused", "Using the previously loaded document context…", 55, 0);
         }
     }
-    for (int i = 0; i < bound_documents.len && !reuse_saved_document_context; i++) {
+    if(reuse_stable_document_prefix&&
+       !conversation_document_context_append(g,conversation_id,&doc_evidence)){
+        vision_turn_close(g,&vision_turn);free(doc_evidence.data);free(image_blocks.data);
+        return chat_context_error(fd,&web_progress,409,"document_context_invalid",
+                                  "The saved document context is unreadable.");
+    }
+    for (int i = 0; i < bound_documents.len && !reuse_saved_document_context &&
+                        !reuse_stable_document_prefix; i++) {
         int supplied = 0;
         for (int j = 0; have_attachments && j < attach_ids->len; j++) {
             jval *idv = attach_ids->kids[j];
@@ -12882,8 +12975,11 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
         const char *filename = new_documents.len ? new_documents.items[0].filename :
                                bound_documents.len ? bound_documents.items[0].filename :
                                "Attached document";
-        file_sse_activity(&web_progress, filename, "passages",
-                          "Selecting the most relevant passages and citations…", 65, 0);
+        file_sse_activity(&web_progress,filename,
+            (reuse_saved_document_context||reuse_stable_document_prefix)?"ready":"passages",
+            (reuse_saved_document_context||reuse_stable_document_prefix)?
+                "Previously extracted document context is ready.":
+                "Selecting the most relevant passages and citations…",65,0);
     }
     if (conversation_id) {
         if (new_documents.len && !conversation_documents_merge(g, conversation_id, &new_documents)) {
@@ -12895,6 +12991,15 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
             free(doc_evidence.data); free(image_blocks.data);
             return chat_context_error(fd, &web_progress, 500, "documents_write_failed",
                                       "The conversation document manifest could not be saved.");
+        }
+        int all_full=(!new_documents.len||conversation_documents_all_full(&new_documents))&&
+                     (!bound_documents.len||conversation_documents_all_full(&bound_documents));
+        if(all_full&&doc_evidence.data&&doc_evidence.len&&
+           !reuse_saved_document_context&&!reuse_stable_document_prefix&&
+           !conversation_document_context_save(g,conversation_id,doc_evidence.data)){
+            free(doc_evidence.data);free(image_blocks.data);
+            return chat_context_error(fd,&web_progress,500,"document_context_write_failed",
+                                      "The extracted document context could not be saved.");
         }
     }
 
@@ -12992,23 +13097,18 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
     web_append_grounding_requirements(&web_evidence, web_high_stakes,
                                       fast_web_synthesis);
 
-    /* Keep the user-facing follow-up small, but retain fresh bounded evidence
-       for Qwen's compaction path. The extraction cache makes this local-only
-       rebuild cheap; it must not become another model call. */
+    /* Native stateful engines need the full evidence only for cold recovery or
+       compaction.  Read the exact admitted sidecar rather than rebuilding
+       query evidence on every hot follow-up. */
     TextBuffer pinned_doc_evidence = {0}, pinned_image_scratch = {0};
     if (reuse_saved_document_context) {
-        for (int i = 0; i < bound_documents.len; i++) {
-            int status; char code[64], message[160];
-            unsigned long tokens = 0; int retrieval = 0;
-            if (!attachment_augment(g, bound_documents.items[i].attachment_id,
-                                    &pinned_doc_evidence, &pinned_image_scratch,
-                                    &status, code, sizeof(code), message, sizeof(message),
-                                    original_text, &tokens, &retrieval, NULL)) {
-                free(doc_evidence.data); free(image_blocks.data);
-                free(chutni_evidence.data); free(web_evidence.data);
-                free(pinned_doc_evidence.data); free(pinned_image_scratch.data);
-                return chat_context_error(fd, &web_progress, status, code, message);
-            }
+        if(!conversation_document_context_append(g,conversation_id,
+                                                 &pinned_doc_evidence)){
+            free(doc_evidence.data);free(image_blocks.data);
+            free(chutni_evidence.data);free(web_evidence.data);
+            free(pinned_doc_evidence.data);free(pinned_image_scratch.data);
+            return chat_context_error(fd,&web_progress,409,"document_context_invalid",
+                                      "The saved document context is unreadable.");
         }
     } else if (doc_evidence.data && doc_evidence.len) {
         text_add_n(&pinned_doc_evidence, doc_evidence.data, doc_evidence.len);
@@ -13056,11 +13156,13 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
     TextBuffer payload = {0};
     text_add(&payload, "{");
     int wrote = 0;
+    int force_prompt_cache=prompt_prefix_cache&&conversation_id;
     for (int i = 0; i < body->len; i++) {
         if (!strcmp(body->keys[i], "messages") || !strcmp(body->keys[i], "attachment_ids") ||
             !strcmp(body->keys[i], "web") || !strcmp(body->keys[i], "web_urls") ||
             !strcmp(body->keys[i], "directory_context") ||
             !strcmp(body->keys[i], "pinned_context") ||
+            (force_prompt_cache&&!strcmp(body->keys[i],"cache_prompt")) ||
             ((grounded_visual_synthesis || grounded_document_synthesis || fast_web_synthesis) &&
              (!strcmp(body->keys[i], "thinking") ||
               !strcmp(body->keys[i], "chat_template_kwargs") ||
@@ -13082,6 +13184,10 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
         if (wrote) text_add(&payload, ",");
         text_add(&payload, "\"max_tokens\":4096");
         wrote = 1;
+    }
+    if(force_prompt_cache){
+        if(wrote)text_add(&payload,",");
+        text_add(&payload,"\"cache_prompt\":true");wrote=1;
     }
     if (grounded_visual_synthesis || grounded_document_synthesis || fast_web_synthesis) {
         /* Synthesis is a bounded evidence rewrite, not an open-ended reasoning
@@ -13154,6 +13260,15 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
         messages_wrote = 1;
         free(merged_system.data);
     }
+    int first_user_idx=last_idx;
+    if(reuse_stable_document_prefix){
+        for(int i=0;i<messages->len;i++){
+            jval *candidate=messages->kids[i];
+            jval *role=candidate&&candidate->t==J_OBJ?json_get(candidate,"role"):NULL;
+            if(role&&role->t==J_STR&&!strcmp(role->str,"user")){first_user_idx=i;break;}
+        }
+    }
+    int document_target_idx=reuse_stable_document_prefix?first_user_idx:last_idx;
     for (int i = 0; i < messages->len; i++) {
         jval *message_role = messages->kids[i] && messages->kids[i]->t == J_OBJ
             ? json_get(messages->kids[i], "role") : NULL;
@@ -13170,26 +13285,34 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
             !strcmp(message_role->str, "assistant")) continue;
         if (messages_wrote) text_add(&payload, ",");
         messages_wrote = 1;
-        if (i != last_idx) { text_json_value(&payload, messages->kids[i]); continue; }
+        if (i != last_idx && i != document_target_idx) {
+            text_json_value(&payload, messages->kids[i]); continue;
+        }
+        jval *target_msg=messages->kids[i];
+        jval *target_content=target_msg&&target_msg->t==J_OBJ?
+                             json_get(target_msg,"content"):NULL;
+        const char *target_text=target_content&&target_content->t==J_STR?
+                                target_content->str:"";
         text_add(&payload, "{");
         int mwrote = 0;
-        for (int k = 0; k < last_msg->len; k++) {
-            if (!strcmp(last_msg->keys[k], "content")) continue;
+        for (int k = 0; k < target_msg->len; k++) {
+            if (!strcmp(target_msg->keys[k], "content")) continue;
             if (mwrote) text_add(&payload, ",");
-            text_json_string(&payload, last_msg->keys[k]); text_add(&payload, ":");
-            text_json_value(&payload, last_msg->kids[k]);
+            text_json_string(&payload, target_msg->keys[k]); text_add(&payload, ":");
+            text_json_value(&payload, target_msg->kids[k]);
             mwrote = 1;
         }
         if (mwrote) text_add(&payload, ",");
         TextBuffer full_text = {0};
-        text_add(&full_text, original_text);
-        if (doc_evidence.data) text_add(&full_text, doc_evidence.data);
-        if (chutni_evidence.data) text_add(&full_text, chutni_evidence.data);
-        if (web_evidence.data) text_add(&full_text, web_evidence.data);
+        text_add(&full_text,target_text);
+        if(i==document_target_idx&&doc_evidence.data)
+            text_add(&full_text,doc_evidence.data);
+        if(i==last_idx&&chutni_evidence.data)text_add(&full_text,chutni_evidence.data);
+        if(i==last_idx&&web_evidence.data)text_add(&full_text,web_evidence.data);
         /* Keep the ordinary text-only OpenAI shape for local backends that do
            not implement multimodal content arrays. Use an array only when an
            image actually needs one; web evidence alone is still plain text. */
-        if (image_blocks.data) {
+        if (i==last_idx&&image_blocks.data) {
             text_add(&payload, "\"content\":[{\"type\":\"text\",\"text\":");
             text_json_string(&payload, full_text.data ? full_text.data : "");
             text_add(&payload, "}");
@@ -13204,12 +13327,19 @@ static int chat_completions_forward(Gateway *g, int fd, const SamosaHttpRequest 
     }
     free(synthesis_instruction.data);
     text_add(&payload, "]");
-    /* Qwen uses this separate field only while rebuilding a compacted native
-       session. The same evidence remains in the current user turn above, so
-       ordinary backends can ignore the field without changing their prompt. */
+    /* Native engines use this separate field only while rebuilding cold or
+       compacted state. Stateless/prompt-cache backends already receive the
+       evidence in the selected user turn above. */
     const char *pinned_context = pinned_doc_evidence.data && pinned_doc_evidence.len
         ? pinned_doc_evidence.data : doc_evidence.data;
-    if (pinned_context && *pinned_context) {
+    /* Qwen can read the shared per-conversation sidecar itself if automatic
+       compaction actually runs.  Omitting this large recovery-only field on a
+       normal hot follow-up also keeps the gateway on its ordinary timeout
+       path. Maple still receives it because a cold native restart currently
+       rebuilds from the request rather than a sealed session. */
+    int qwen_hot_followup=reuse_saved_document_context&&!strcmp(g->backend,"qwen");
+    if (pinned_context && *pinned_context && native_conversation_state &&
+        !qwen_hot_followup) {
         text_add(&payload, ",\"pinned_context\":");
         text_json_string(&payload, pinned_context);
     }
@@ -19037,7 +19167,9 @@ static int compact_request(Gateway *g, int fd, const SamosaHttpRequest *request)
         return proxy_request(g, fd, request);
     }
     TextBuffer pinned = {0}, image_blocks = {0};
-    for (int i = 0; i < documents.len; i++) {
+    int used_saved_context=conversation_documents_full_context_current(g,&documents)&&
+        conversation_document_context_append(g,conversation->str,&pinned);
+    for (int i = 0; i < documents.len && !used_saved_context; i++) {
         int status, retrieval = 0;
         char code[64], message[160];
         unsigned long tokens = 0;

--- a/tests/fake_openai_backend.c
+++ b/tests/fake_openai_backend.c
@@ -573,6 +573,34 @@ static int handler(SamosaHttpServer *server, int fd,
                 "\"message\":{\"role\":\"assistant\",\"content\":\"saw the document attachment\"}}]}", NULL);
     }
     if (!strcmp(request->method, "POST") && !strcmp(request->path, "/v1/chat/completions") &&
+        strstr(request->body, "stable prefix initial probe") &&
+        !strstr(request->body, "stable prefix followup probe")) {
+        const char *reply = strstr(request->body, "LATE_FILE_SENTINEL") &&
+                            strstr(request->body, "\"cache_prompt\":true") &&
+                            !strstr(request->body, "\"pinned_context\"")
+            ? "stable prefix initial ok" : "stable prefix initial missing";
+        char body[512];
+        snprintf(body, sizeof(body),
+            "{\"choices\":[{\"index\":0,\"finish_reason\":\"stop\","
+            "\"message\":{\"role\":\"assistant\",\"content\":\"%s\"}}]}", reply);
+        return samosa_http_response(fd, 200, "application/json", body, NULL);
+    }
+    if (!strcmp(request->method, "POST") && !strcmp(request->path, "/v1/chat/completions") &&
+        strstr(request->body, "stable prefix followup probe")) {
+        const char *evidence = strstr(request->body, "LATE_FILE_SENTINEL");
+        const char *prior = strstr(request->body, "stable prefix initial ok");
+        const char *reply = evidence && prior && evidence < prior &&
+                            !strstr(evidence + 1, "LATE_FILE_SENTINEL") &&
+                            strstr(request->body, "\"cache_prompt\":true") &&
+                            !strstr(request->body, "\"pinned_context\"")
+            ? "stable prefix followup ok" : "stable prefix followup missing";
+        char body[512];
+        snprintf(body, sizeof(body),
+            "{\"choices\":[{\"index\":0,\"finish_reason\":\"stop\","
+            "\"message\":{\"role\":\"assistant\",\"content\":\"%s\"}}]}", reply);
+        return samosa_http_response(fd, 200, "application/json", body, NULL);
+    }
+    if (!strcmp(request->method, "POST") && !strcmp(request->path, "/v1/chat/completions") &&
         strstr(request->body, "attachment text probe")) {
         /* Phase 1 deep-file regression: the decisive fact is deliberately
            beyond both the old native-summary and opening-excerpt budgets. */
@@ -590,7 +618,8 @@ static int handler(SamosaHttpServer *server, int fd,
     }
     if (!strcmp(request->method, "POST") && !strcmp(request->path, "/v1/chat/completions") &&
         strstr(request->body, "attachment text followup probe")) {
-        const char *reply = strstr(request->body, "LATE_FILE_SENTINEL") &&
+        const char *reply = !strstr(request->body, "LATE_FILE_SENTINEL") &&
+                            !strstr(request->body, "\"pinned_context\"") &&
                             strstr(request->body, "Attached document context already loaded")
             ? "saw the bound text document" : "missing bound text document";
         char body[512];

--- a/tests/test_attachments.sh
+++ b/tests/test_attachments.sh
@@ -138,13 +138,16 @@ PY
   DOCS=$(curl -sS -H "X-Samosa-Token: $TOKEN" "http://127.0.0.1:$PORT/v1/conversations/$CONV_ID/documents")
   printf '%s' "$DOCS" | grep -q "\"attachment_id\":\"$TEXT_ID\"" || { echo "FAIL: manifest did not persist the document: $DOCS"; exit 1; }
   [ -s "$HOME_DIR/chats/$CONV_ID/documents.json" ] || { echo "FAIL: durable document manifest was not written to the conversation directory"; exit 1; }
+  [ -s "$HOME_DIR/chats/$CONV_ID/document-context.txt" ] || { echo "FAIL: admitted document context sidecar was not written"; exit 1; }
+  grep -q 'LATE_FILE_SENTINEL' "$HOME_DIR/chats/$CONV_ID/document-context.txt" || { echo "FAIL: saved document context lost the admitted tail"; exit 1; }
   printf '%s' "$DOCS" | grep -q '"filename":"late-notes.py"' || { echo "FAIL: manifest lost the document filename: $DOCS"; exit 1; }
   printf '%s' "$DOCS" | grep -q '"mode":"full"' || { echo "FAIL: new document should begin in full mode: $DOCS"; exit 1; }
 
   # The fake backend does not write a native Qwen KV session. Mark the
   # conversation as resumable so this fixture exercises the gateway's saved-
-  # session follow-up path: the new user turn gets a continuity note while
-  # pinned_context retains the bounded local evidence for compaction.
+  # session follow-up path: the new user turn gets only a continuity note.
+  # Recovery/compaction can read document-context.txt on demand, so the large
+  # evidence and pinned_context must stay off the ordinary hot request.
   mkdir -p "$HOME_DIR/chats/$CONV_ID"
   touch "$HOME_DIR/chats/$CONV_ID/session.qws"
   RESP=$(curl -sS -H "X-Samosa-Token: $TOKEN" -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
@@ -155,6 +158,7 @@ PY
   STATUS=$(curl -sS -o /dev/null -w '%{http_code}' -H "X-Samosa-Token: $TOKEN" -X DELETE \
     "http://127.0.0.1:$PORT/v1/conversations/$CONV_ID/documents/$TEXT_ID")
   [ "$STATUS" = "200" ] || { echo "FAIL: detaching a bound document should be 200, got $STATUS"; exit 1; }
+  [ ! -e "$HOME_DIR/chats/$CONV_ID/document-context.txt" ] || { echo "FAIL: detaching a document left stale saved evidence"; exit 1; }
   DOCS=$(curl -sS -H "X-Samosa-Token: $TOKEN" "http://127.0.0.1:$PORT/v1/conversations/$CONV_ID/documents")
   [ "$(printf '%s' "$DOCS" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("documents", [])))')" = "0" ] || { echo "FAIL: detached document remained in the manifest: $DOCS"; exit 1; }
   RESP=$(curl -sS -H "X-Samosa-Token: $TOKEN" -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \

--- a/tests/test_document_context_prefix.sh
+++ b/tests/test_document_context_prefix.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -eu
+
+# Backend-neutral document reuse for llama.cpp text models.  The second turn
+# must reconstruct the same first-user prompt prefix, request llama.cpp prompt
+# caching, and keep recovery-only pinned context out of the hot request.
+
+BUILD_DIR="${BUILD_DIR:-build}"
+GATEWAY="${SAMOSA_COMPILED_GATEWAY:-./$BUILD_DIR/samosa-gateway}"
+BACKEND="${SAMOSA_FAKE_BACKEND:-./$BUILD_DIR/test_fake_openai_backend}"
+EXTRACT="${SAMOSA_EXTRACT:-./$BUILD_DIR/samosa-extract}"
+OCR="${SAMOSA_OCR:-./$BUILD_DIR/samosa-ocr}"
+
+if [ ! -x "$EXTRACT" ]; then
+  echo "test_document_context_prefix.sh: SKIP (no samosa-extract build)"
+  exit 0
+fi
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/document_prefix_test.XXXXXX")
+HOME_DIR="$TMP/home"
+PORT=19022
+GW_PID=""
+
+cleanup() {
+  [ -z "$GW_PID" ] || kill "$GW_PID" 2>/dev/null || true
+  [ -z "$GW_PID" ] || wait "$GW_PID" 2>/dev/null || true
+  curl -sS -m 2 -X POST "http://127.0.0.1:$((PORT + 1))/shutdown" >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$HOME_DIR/models/ornith-9b" "$HOME_DIR/qwen-model"
+printf 'fixture\n' >"$HOME_DIR/models/ornith-9b/Ornith-1.0-9B-Q4_K_M.gguf"
+printf 'experts-fixture\n' >"$HOME_DIR/qwen-model/experts.bin"
+printf 'ornith\n' >"$HOME_DIR/model-backend"
+printf '<!doctype html><title>Samosa</title>\n' >"$TMP/app.html"
+printf 'png\n' >"$TMP/logo.png"
+printf 'tokenizer-fixture\n' >"$TMP/tokenizer.json"
+
+SAMOSA_HOME="$HOME_DIR" \
+SAMOSA_PORT="$PORT" \
+SAMOSA_BACKEND_PORT=$((PORT + 1)) \
+SAMOSA_APP_HTML="$TMP/app.html" \
+SAMOSA_APP_LOGO="$TMP/logo.png" \
+SAMOSA_QWEN_ENGINE="$BACKEND" \
+SAMOSA_QWEN_MODEL="$HOME_DIR/qwen-model" \
+SAMOSA_TOKENIZER="$TMP/tokenizer.json" \
+SAMOSA_BONSAI_SERVER="$BACKEND" \
+SAMOSA_ORNITH_MODEL="$HOME_DIR/models/ornith-9b/Ornith-1.0-9B-Q4_K_M.gguf" \
+SAMOSA_EXTRACT="$EXTRACT" \
+SAMOSA_OCR="$OCR" \
+  "$GATEWAY" >"$TMP/stdout.log" 2>"$TMP/stderr.log" &
+GW_PID=$!
+
+i=0
+while [ "$i" -lt 100 ]; do
+  HEALTH=$(curl -fsS "http://127.0.0.1:$PORT/healthz" 2>/dev/null || true)
+  printf '%s' "$HEALTH" | grep -q '"ready":true' &&
+    printf '%s' "$HEALTH" | grep -q '"backend":"ornith"' && break
+  sleep 0.05
+  i=$((i + 1))
+done
+TOKEN=$(cat "$HOME_DIR/run/ui-token")
+HEALTH=$(curl -fsS "http://127.0.0.1:$PORT/healthz")
+MODEL_VERSION=$(printf '%s' "$HEALTH" | python3 -c 'import json,sys; print(json.load(sys.stdin)["model_version"])')
+
+python3 - "$TMP/notes.txt" <<'PY'
+import sys
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    f.write("BEGIN_FILE\n")
+    f.write("A" * 7200)
+    f.write("\nLATE_FILE_SENTINEL\n")
+PY
+RESP=$(curl -fsS -H "X-Samosa-Token: $TOKEN" \
+  -H "X-Samosa-Filename-B64: $(printf 'notes.txt' | base64)" \
+  -X POST "http://127.0.0.1:$PORT/v1/attachments" --data-binary "@$TMP/notes.txt")
+ATTACHMENT_ID=$(printf '%s' "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+CONVERSATION_ID=ornith-stable-prefix
+
+RESP=$(curl -fsS -H "X-Samosa-Token: $TOKEN" -H 'Content-Type: application/json' \
+  -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+  -d "{\"model\":\"ornith-1.0-9b\",\"model_id\":\"ornith\",\"model_version\":\"$MODEL_VERSION\",\"conversation_id\":\"$CONVERSATION_ID\",\"messages\":[{\"role\":\"user\",\"content\":\"stable prefix initial probe\"}],\"attachment_ids\":[\"$ATTACHMENT_ID\"],\"stream\":false}")
+printf '%s' "$RESP" | grep -q 'stable prefix initial ok' || {
+  echo "FAIL: first Ornith document turn did not establish a cacheable prefix: $RESP"; exit 1;
+}
+[ -s "$HOME_DIR/chats/$CONVERSATION_ID/document-context.txt" ] || {
+  echo "FAIL: stable document context sidecar was not saved"; exit 1;
+}
+
+RESP=$(curl -fsS -H "X-Samosa-Token: $TOKEN" -H 'Content-Type: application/json' \
+  -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+  -d "{\"model\":\"ornith-1.0-9b\",\"model_id\":\"ornith\",\"model_version\":\"$MODEL_VERSION\",\"conversation_id\":\"$CONVERSATION_ID\",\"messages\":[{\"role\":\"user\",\"content\":\"stable prefix initial probe\"},{\"role\":\"assistant\",\"content\":\"stable prefix initial ok\"},{\"role\":\"user\",\"content\":\"stable prefix followup probe\"}],\"stream\":false}")
+printf '%s' "$RESP" | grep -q 'stable prefix followup ok' || {
+  echo "FAIL: Ornith follow-up did not reuse a stable cached prefix: $RESP"; exit 1;
+}
+
+echo "test_document_context_prefix.sh: PASS"

--- a/tests/test_samosa_serve.c
+++ b/tests/test_samosa_serve.c
@@ -79,6 +79,28 @@ int main(void){
     teacher_state_end(&sealed);
     assert(!remove(sealed_path));assert(!rmdir(sealed_dir));
 
+    int live_types[]={1};
+    Model live={.c={.n_layers=1,.n_kv_heads=2,.head_dim=2,
+        .layer_type=live_types},.max_t=3};
+    live.K=calloc(1,sizeof(float *));live.V=calloc(1,sizeof(float *));
+    live.conv_state=calloc(1,sizeof(float *));live.recurrent_state=calloc(1,sizeof(float *));
+    live.K[0]=calloc(12,sizeof(float));live.V[0]=calloc(12,sizeof(float));
+    live.K[0][0]=11;live.K[0][1]=12;live.K[0][2]=13;live.K[0][3]=14;
+    live.K[0][6]=21;live.K[0][7]=22;live.K[0][8]=23;live.K[0][9]=24;
+    live.V[0][0]=31;live.V[0][6]=41;
+    assert(teacher_state_grow(&live,6,2));
+    assert(live.max_t==6);
+    assert(live.K[0][0]==11&&live.K[0][2]==13);
+    assert(live.K[0][12]==21&&live.K[0][14]==23);
+    assert(live.V[0][0]==31&&live.V[0][12]==41);
+    ResidentSession resident={0};
+    resident.valid=1;resident.tokens=malloc(4*sizeof(int));resident.len=4;
+    resident.capacity=6;strcpy(resident.conversation_id,"hot-fixture");
+    strcpy(resident.session_path,"/tmp/hot-fixture/session.qws");
+    assert(resident_session_matches(&resident,"/tmp/hot-fixture/session.qws"));
+    resident_session_evict(&live,&resident,"unit test");
+    assert(!resident.valid&&!resident.tokens&&live.max_t==0&&resident.evictions==1);
+
     assert(piece_ends_sentence("2003.",5));
     assert(piece_ends_sentence(".\n\n",3));
     assert(piece_ends_sentence(" done!)\n",8));
@@ -120,7 +142,8 @@ int main(void){
     assert(strstr(health,"HTTP/1.1 200 OK"));assert(strstr(health,"\"status\":\"ok\""));
     assert(strstr(health,"\"model_context_limit_tokens\":262144"));
     assert(strstr(health,"\"context_limit_tokens\":131072"));
-    assert(strstr(health,"\"compaction\":{\"auto\":true,\"threshold_percent\":80}"));free(health);
+    assert(strstr(health,"\"compaction\":{\"auto\":true,\"threshold_percent\":80}"));
+    assert(strstr(health,"\"resident_session\":{\"capacity\":1,\"hot\":false"));free(health);
     const char *settings_body="{\"context_tokens\":\"auto\",\"auto_compact\":false,\"compact_threshold_percent\":75}";
     char settings_wire[256];snprintf(settings_wire,sizeof(settings_wire),
         "POST /v1/settings HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: %zu\r\n\r\n%s",
@@ -157,6 +180,15 @@ int main(void){
     assert(terminal_n>0);terminal_wire[terminal_n]=0;
     assert(strstr(terminal_wire,"\"compacted\":true"));
     assert(strstr(terminal_wire,"\"compacted_from_tokens\":100"));
+    close(pair[0]);close(pair[1]);
+
+    assert(!socketpair(AF_UNIX,SOCK_STREAM,0,pair));
+    assert(serve_context_activity(pair[0],"compacting",
+        "Optimizing conversation context…",25,1));
+    terminal_n=recv(pair[1],terminal_wire,sizeof(terminal_wire)-1,0);
+    assert(terminal_n>0);terminal_wire[terminal_n]=0;
+    assert(strstr(terminal_wire,"\"stage\":\"compacting\""));
+    assert(strstr(terminal_wire,"\"indeterminate\":true"));
     close(pair[0]);close(pair[1]);
 
     char *models=request(server.port,"GET /v1/models HTTP/1.1\r\nHost: localhost\r\n\r\n");


### PR DESCRIPTION
Summary:
- keep one bounded hot native conversation for Qwen and Maple
- reuse an exact stable prompt prefix for Ornith and Bonsai
- save full-document evidence locally for recovery and compaction without repeating OCR
- evict safely on switches, pressure, idle time, compaction, settings changes, failures, and shutdown
- document the backend matrix, privacy boundary, concurrency behavior, and checkpoint tradeoff

Validation:
- make test
- make compiled-gateway-test
- make samosa-maple
- installed and checksum-verified local release dev-0800eee7f1fe

Privacy:
- tests use synthetic fixtures only
- no private runtime chats or document contents are included